### PR TITLE
fix: replace course translations that don't have the word course in its source

### DIFF
--- a/scripts/reword_list.csv
+++ b/scripts/reword_list.csv
@@ -20,4 +20,6 @@ course,ومساقات,ومقررات,
 course,مساقاتهم,مقرراتهم,
 course,مساقنا,مقررنا,
 course,مساقاتي,مقرراتي,
+Timed,مؤقّت,موقوت,
+Donate,تبرَّع,المركز,We do not support donations so we repurpose this page
 report_type,يتم الآن إنشاء التقرير,يرجى إنتظار عملية إنشاء التقرير,Add a please wait note

--- a/scripts/reword_translations.py
+++ b/scripts/reword_translations.py
@@ -105,11 +105,19 @@ def create_overrides_po_file(
     combined_dest_po = polib.POFile()
     combined_dest_po.metadata = source_po.metadata
 
+    print(f'## Rewording: {source}  ##')
+
     for entry in source_po.translated_entries():
         has_reword = False
 
         for reword in reword_list:
-            if reword.is_english_loose_match(entry):
+            if reword.is_arabic_strict_match(entry):
+                if not reword.is_english_loose_match(entry):
+                    print(
+                        f'    NOTICE: Could not find English word "{reword.english_word}" in "{entry.msgid}" despite '
+                        f'having "{reword.arabic_word}" in translation.'
+                    )
+
                 has_reword = True
                 entry = reword.reword_entry(entry)
 
@@ -177,7 +185,10 @@ def main(repo_root, *_argv):
         )
 
         verify_course_translation(path=overrides_dest)
+        verify_course_translation(path=combined_dest)
         verify_all_translations(path=overrides_dest, reword_list=reword_list)
+
+    print('Finished rewording successfully')
 
 
 if __name__ == '__main__':

--- a/translation-overrides/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
+++ b/translation-overrides/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
@@ -53,26 +53,6 @@ msgstr "الفترة الزمنية التي تسبق انتهاء المقرر 
 msgid "Congratulations!  You are now enrolled in {course_name}"
 msgstr "تهانينا! أنت الآن ملتحق في المقرر {course_name}"
 
-#: common/djangoapps/student/models/course_enrollment.py
-msgid ""
-"It expect that the data will be provided in a csv file format with"
-"                     first row being the header and columns will be as "
-"follows:                     user_id, username, email, course_id, "
-"is_verified, verification_date"
-msgstr ""
-"من المتوقع أن يتم توفير البيانات بتنسيق ملف csv بحيث يكون الصف الأول هو "
-"العنوان وستكون الأعمدة على النحو التالي: معرف المستخدم ، اسم المستخدم ، "
-"البريد الإلكتروني ، معرف الدورة ، تم التحقق منه ، تاريخ التحقق"
-
-#: common/djangoapps/student/models/course_enrollment.py
-msgid ""
-"It expect that the data will be provided in a csv file format with"
-"                     first row being the header and columns will be as "
-"follows:                     course_id, username, mode"
-msgstr ""
-"تتوقع أن يتم توفير البيانات بتنسيق ملف csv مع        سيكون الصف الأول هو "
-"الرأس والأعمدة كما يلي: معرف_الدورة، اسم المستخدم، الوضع"
-
 #: common/djangoapps/student/models/user.py
 #, python-brace-format
 msgid "{platform_name} Honor Code Certificate for {course_name}"
@@ -128,27 +108,6 @@ msgstr "تمنعك شهادتك من إلغاء تسجيلك في هذا الم�
 msgid "Course {course_id} requires {prerequisite_course_id}"
 msgstr "يستوجب المقرر {course_id} المتطلّب {prerequisite_course_id}"
 
-#: common/djangoapps/xblock_django/admin.py
-msgid ""
-"Only XBlocks listed in a course's Advanced Module List can be flagged as "
-"deprecated. Remember to update XBlockStudioConfiguration support state "
-"accordingly, as deprecated does not impact whether or not new XBlock "
-"instances can be created in Studio."
-msgstr ""
-"فقط يمكن تحديد XBlocks المدرجة في قائمة Advanced Module للدورة التدريبية "
-"بعلامة تجاهل. تذكر تحديث حالة دعم XBlockStudioConfiguration وفقًا لذلك، لأن "
-"حالة \"تجاهل\" لا تؤثر على إمكانية إنشاء حالات XBlock جديدة في Studio من "
-"عدمها. "
-
-#: common/djangoapps/xblock_django/admin.py
-msgid ""
-"Enabled XBlock/template combinations with full or provisional support can "
-"always be created in Studio. Unsupported XBlock/template combinations "
-"require course author opt-in."
-msgstr ""
-"يمكن دائمًا إنشاء تركيبات القالب/XBlock ممكنة مع دعم كامل أو مؤقت في Studio."
-" تتطلب تركيبات القالب/XBlock موافقة مؤلف الدورة التدريبية.    "
-
 #: common/templates/student/edx_ace/accountactivation/email/body.html
 #, python-format
 msgid ""
@@ -159,28 +118,6 @@ msgstr ""
 "أنت على وشك الانتهاء! استخدم الرابط أدناه لتنشيط حسابك للوصول إلى مقررات "
 "%(platform_name)s التعليمية عالية الجودة. الرجاء الملاحظة أن لا يمكن تسجيل "
 "الدخول مرة أخرى إلى حسابك حتى تقوم بتنشيطه."
-
-#: common/templates/student/edx_ace/proctoringrequirements/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                    Proctoring requirements for %(course_name)s\n"
-"                "
-msgstr ""
-"\n"
-" متطلبات المراقبة لـ %(course_name)s\n"
-"                "
-
-#: common/templates/student/edx_ace/proctoringrequirements/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                    Proctored exams are timed exams that you take while proctoring software monitors your computer's desktop, webcam video, and audio. Your course uses %(proctoring_provider)s software for proctoring.\n"
-"                "
-msgstr ""
-"\n"
-"الامتحانات التي يتم مراقبتها هي اختبارات محددة بوقت يتم إجراؤها أثناء قيام برنامج المراقبة بمراقبة سطح المكتب لجهاز الكمبيوتر الخاص بك وفيديو كاميرا الويب والصوت. تستخدم مقررك الدراسي برنامج%(proctoring_provider)s للمراقبة\n"
-"                "
 
 #: lms/djangoapps/badges/events/course_complete.py
 #, python-brace-format
@@ -223,16 +160,6 @@ msgstr ""
 
 #: lms/djangoapps/badges/models.py
 msgid ""
-"On each line, put the number of enrolled courses to award a badge for, a "
-"comma, and the slug of a badge class you have created that has the issuing "
-"component 'openedx__course'. For example: 3,enrolled_3_courses"
-msgstr ""
-"في كل سطر، ضع عنوانًا مختصرًا لجائزة على عدد الدورات المسجلة مع فاصلة "
-"وعنوانًا مختصرًا للفئة التي قمت بإنشائها وتحتوي على عنصر الإصدار "
-"\"openedx__course\". على سبيل المثال: 3,enrolled_3_courses"
-
-#: lms/djangoapps/badges/models.py
-msgid ""
 "Each line is a comma-separated list. The first item in each line is the slug"
 " of a badge class you have created that has an issuing component of "
 "'openedx__course'. The remaining items in each line are the course keys the "
@@ -246,11 +173,9 @@ msgstr ""
 "slug_for_compsci_courses_group_badge,course-v1:CompSci+Course+First,course-v1:CompsSci+Course+Second"
 "  "
 
-#. Translators: This string is used across Open edX installations
-#. as a callback to edX. Please do not translate `edX.org`
-#: lms/djangoapps/branding/api.py
-msgid "Take free online courses at edX.org"
-msgstr "الحصول على دورات مجانية في edX.org"
+#: lms/djangoapps/branding/api.py lms/templates/static_templates/donate.html
+msgid "Donate"
+msgstr "المركز"
 
 #. Translators: Bulk email from address e.g. ("Physics 101" Course Staff)
 #: lms/djangoapps/bulk_email/tasks.py
@@ -321,22 +246,18 @@ msgstr ""
 " المتعمَد لدى {platform_name} واستكمَل كافة المهام المطلوبة في هذا المقرر "
 "بموجب التعليمات."
 
-#. Translators:  This text represents the verification of the certificate
+#. Translators:  This text fragment appears after the student's name
+#. (displayed in a large font) on the certificate
+#. screen.  The text describes the accomplishment represented by the
+#. certificate information displayed to the user
 #: lms/djangoapps/certificates/views/webview.py
 #, python-brace-format
 msgid ""
-"This is a valid {platform_name} certificate for {user_name}, who "
-"participated in {partner_short_name} {course_number}"
+"successfully completed, received a passing grade, and was awarded this "
+"{platform_name} {certificate_type} Certificate of Completion in "
 msgstr ""
-"هذه شهادة صالحة من {platform_name} للمستخدم {user_name} الذي شارك في "
-"{partner_short_name} {course_number}"
-
-#. Translators:  This text is bound to the HTML 'title' element of the page
-#. and appears in the browser title bar
-#: lms/djangoapps/certificates/views/webview.py
-#, python-brace-format
-msgid "{partner_short_name} {course_number} Certificate | {platform_name}"
-msgstr "شهادة {partner_short_name} {course_number} | {platform_name}"
+"قد نجح في إتمام المقرر ونال درجة النجاح، ومُنِح بناءً على ذلك شهادة إتمام "
+"{certificate_type} من {platform_name}  في  "
 
 #. Translators: This text describes the purpose (and therefore, value) of a
 #. course certificate
@@ -348,6 +269,15 @@ msgid ""
 msgstr ""
 "تُقرّ المنصّة {platform_name} الإنجازات من خلال شهادات، تُمنح مقابل أنشطة "
 "المقرر التي يُكملها طلّاب {platform_name}"
+
+#. Translators:  This text describes (at a high level) the mission and charter
+#. the edX platform and organization
+#: lms/djangoapps/certificates/views/webview.py
+#, python-brace-format
+msgid "{platform_name} offers interactive online classes and MOOCs."
+msgstr ""
+"تُقدّم المنصّة {platform_name} صفوف ومقررات MOOC تفاعلية مُتاحة عبر "
+"الإنترنت."
 
 #. Translators:  This text represents the description of course
 #: lms/djangoapps/certificates/views/webview.py
@@ -392,16 +322,6 @@ msgstr ""
 "التوجه إلى صفحة الدفع الخاصة بالمقرر(ات) المستضافة من قبل خدمة التجارة "
 "الإلكترونية."
 
-#: lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
-msgid ""
-"\n"
-"                            Unsubscribe from goal reminder emails for this course\n"
-"                        "
-msgstr ""
-"\n"
-"                            إلغاء الاشتراك من رسائل البريد الإلكتروني الخاصة بتذكيرالاهدف لهذه الدورة\n"
-"                        "
-
 #: lms/djangoapps/course_home_api/admin.py openedx/features/discounts/admin.py
 msgid ""
 "If any of these values is left empty or \"Unknown\", then their value at "
@@ -419,27 +339,12 @@ msgid "Course is full"
 msgstr "المقرر كامل الآن"
 
 #: lms/djangoapps/course_home_api/outline/views.py
-msgid "'course_id' is required."
-msgstr "'course_id' مطلوب"
-
-#: lms/djangoapps/course_home_api/outline/views.py
-msgid "Only 'course_id' is expected."
-msgstr "يتوقع إدراج 'course_id' فقط"
-
-#: lms/djangoapps/course_home_api/outline/views.py
 msgid "Your course goal has been successfully set."
 msgstr "تم ضبط هدف مقررك بنجاح"
 
 #: lms/djangoapps/course_home_api/outline/views.py
 msgid "Course goal updated successfully."
 msgstr "تم تحديث هدف المقرر بنجاح"
-
-#. Translators: this string includes wiki markup.  Leave the ** and the _
-#. alone.
-#: lms/djangoapps/course_wiki/views.py
-#, python-brace-format
-msgid "This is the wiki for **{organization}**'s _{course_name}_."
-msgstr "هذا هو ويكي _{course_name}_ الخاص بـ**{organization}**."
 
 #: lms/djangoapps/course_wiki/views.py
 msgid "Course page automatically created."
@@ -472,6 +377,10 @@ msgstr "يجب أن تكون ملتحقًا بالمقرر"
 #: lms/djangoapps/courseware/access_response.py
 msgid "You must be logged in to see this course"
 msgstr "يجب عليك تسجيل الدخول لمشاهدة هذا المقرر"
+
+#: lms/djangoapps/courseware/courses.py
+msgid "Staff Assessment"
+msgstr "تقييم طاقم المقرر"
 
 #: lms/djangoapps/courseware/date_summary.py
 msgid ""
@@ -531,12 +440,6 @@ msgid ""
 msgstr "أنشئ و أدِر مكتبة من مقروءات المقرر، الكتب، و الفصول."
 
 #: lms/djangoapps/courseware/plugins.py
-msgid "Provide an in-course calculator for simple and complex calculations."
-msgstr ""
-"وفِّر آلة حاسبة أثناء الدورة التدريبية لإجراء العمليات الحسابية البسيطة "
-"والمعقدة."
-
-#: lms/djangoapps/courseware/plugins.py
 msgid ""
 "Maintain exam integrity by enabling a proctoring solution for your course"
 msgstr "حافظ على نزاهة الامتحانات من خلال تفعيل وسيلة مراقبة لمقررك "
@@ -565,29 +468,10 @@ msgstr ""
 
 #: lms/djangoapps/courseware/views/views.py
 msgid ""
-"You are enrolled in the audit track for this course. The audit track does "
-"not include a certificate."
-msgstr ""
-"أنت الآن مسجل في مسار التدقيق لهذه الدورة. لا يتضمن مسار التدقيق شهادة."
-
-#: lms/djangoapps/courseware/views/views.py
-msgid ""
 "You are enrolled in the honor track for this course. The honor track does "
 "not include a certificate."
 msgstr ""
 "أنت مسجل في المسار التشريفي لهذا المقرر. لا يتضمن المسار التشريفي أية شهادة."
-
-#: lms/djangoapps/courseware/views/views.py
-msgid ""
-"We're creating your certificate. You can keep working in your courses and a "
-"link to it will appear here and on your Dashboard when it is ready."
-msgstr ""
-"جاري إنشاء شهادتك. يمكنك متابعة العمل في الدورات وسوف يظهر رابط لشهادتك هنا "
-"على لوح المعلومات عندما تصبح جاهزة."
-
-#: lms/djangoapps/courseware/views/views.py
-msgid "Please contact your course team if you have any questions."
-msgstr "تواصل مع فريق العمل الخاص بالدورة في حال كان لديك أية اسئلة . "
 
 #: lms/djangoapps/courseware/views/views.py
 msgid "You've earned a certificate for this course."
@@ -631,14 +515,6 @@ msgstr ""
 
 #: lms/djangoapps/courseware/views/views.py
 msgid ""
-"Tell us about your learning or professional goals. How will a Verified "
-"Certificate in this course help you achieve these goals?"
-msgstr ""
-"أخبرنا عن أهدافك العلمية والمهنيّة. كيف سيساعدك الحصول على شهادة موثّقة في "
-"تحقيق هذه الأهداف؟"
-
-#: lms/djangoapps/courseware/views/views.py
-msgid ""
 "Tell us about your plans for this course. What steps will you take to help "
 "you complete the course work and receive a certificate?"
 msgstr ""
@@ -653,26 +529,6 @@ msgid ""
 msgstr ""
 "اختر المقرر الذي ترغب بالحصول على شهادة موثّقة له. في حال لم يظهر المقرر ضمن"
 " القائمة، يُرجى التأكّد من أنك قد سجّلت في مسار مراقب لهذا المقرر."
-
-#: lms/djangoapps/discussion/templates/discussion/edx_ace/reportedcontentnotification/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                        %(course_name)s: Reported content awaits review\n"
-"                    "
-msgstr ""
-"\n"
-"                        %(course_name)s: المحتوى المبلغ عنه في انتظار المراجعة\n"
-"                    "
-
-#: lms/djangoapps/instructor/services.py
-#, python-brace-format
-msgid ""
-"A proctored exam attempt for {exam_name} in {course_name} by username: {student_username} was reviewed as {review_status} by the proctored exam review provider.\n"
-"Review link: {review_url}"
-msgstr ""
-"محاولة امتحان مُراقب لـ {exam_name} في  {course_name} حسب اسم المستخدم: لقد تمت مراجعة {student_username} باعتباره {review_status} من قبل مزود معاينة الامتحان المُراقب. \n"
-"Review link: {review_url}"
 
 #: lms/djangoapps/instructor/views/api.py
 #, python-brace-format
@@ -729,31 +585,12 @@ msgid "Please Enter the numeric value for the course price"
 msgstr "يُرجى إدخال قيمة عدّدية لتحديد سعر المقرر"
 
 #: lms/djangoapps/instructor/views/instructor_dashboard.py
-#, python-brace-format
-msgid "CourseMode with the mode slug({mode_slug}) DoesNotExist"
-msgstr "لا يوجد وضع CourseMode باسم ({mode_slug}) "
-
-#: lms/djangoapps/instructor/views/instructor_dashboard.py
-msgid "CourseMode price updated successfully"
-msgstr "حُدِّث سعر CourseMode بنجاح"
-
-#: lms/djangoapps/instructor/views/instructor_dashboard.py
 msgid "Course Info"
 msgstr "معلومات المقرر "
 
 #: lms/djangoapps/instructor/views/tools.py
 msgid "Could not find student enrollment in the course."
 msgstr "تعذر العثور على تسجيل الطالب في المقرر."
-
-#: lms/djangoapps/instructor_task/api_helper.py
-#, python-brace-format
-msgid ""
-"The {report_type} report is being created. To view the status of the report,"
-" see Pending Tasks below. You will be able to download the report when it is"
-" complete."
-msgstr ""
-"يتم إنشاء التقرير {report_type}. لعرض حالة التقرير، انظر المهام المعلقة "
-"أدناه. ستتمكن من تنزيل التقرير عند اكتماله."
 
 #: lms/djangoapps/lms_xblock/mixin.py
 msgid "Course Chrome"
@@ -772,6 +609,21 @@ msgid "If true, can be seen only by course staff, regardless of start date."
 msgstr ""
 "عند اختيارك للقيمة ’true‘، سيُتاح المحتوى لطاقم المقرر فقط، بغض النظر عن "
 "تاريخ بدء المقرر."
+
+#: lms/djangoapps/lms_xblock/mixin.py
+msgid ""
+"A dictionary that maps which groups can be shown this block. The keys are "
+"group configuration ids and the values are a list of group IDs. If there is "
+"no key for a group configuration or if the set of group IDs is empty then "
+"the block is considered visible to all. Note that this field is ignored if "
+"the block is visible_to_staff_only."
+msgstr ""
+"قاموس يحدّد المجموعات التي يمكن إظهارها في هذه الكتلة. المفاتيح السمتخدمة هي"
+" الأرقام التعريفية لإعدادات المجموعات، أمّا القيم فهي عبارة عن لائحة "
+"بالأرقام التعريفية للمجموعات. ستُعتبر الكتلة مرئيّة للجميع في حال لم يتوفّر "
+"مفتاح لإعدادات مجموعة ما، أو كانت المجموعة الخاصّة بأرقام المجموعات "
+"فارغة.يُرجى أخذ العلم بوجوب تجاهل هذا الحقل في حال اقتصرت رؤية الكتلة على "
+"طاقم المقرر. "
 
 #: lms/djangoapps/teams/views.py
 msgid "course_id must be provided"
@@ -809,52 +661,14 @@ msgstr "المقرر الذي تنطبق عليه هذه المهلة النها
 msgid "This course doesn't support paid certificates"
 msgstr "لا يدعم هذا المقرر الشهادات مدفوعة القيمة."
 
-#: lms/templates/bulk_email/edx_ace/bulkemail/email/body.html
-msgid ""
-"\n"
-"            To stop receiving email like this, update your course email settings\n"
-"          "
-msgstr ""
-"\n"
-"لإيقاف تلقي بريد إلكتروني مثل هذا ، قم بتحديث إعدادات البريد الإلكتروني للدورة التدريبية\n"
-"          "
-
-#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
-#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
-#, python-format
-msgid "Welcome to %(course_name)s"
-msgstr "مرحبا بك في %(course_name)s"
-
 #: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
 msgid "You may access your course."
 msgstr "يمكنك الدخول إلى مقررك."
-
-#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
-#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
-#, python-format
-msgid "Sincerely yours, The %(course_name)s Team"
-msgstr "مع خالص الشكر، فريق ال%(course_name)s"
 
 #: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
 #, python-format
 msgid "You may access your course at: %(course_url)s."
 msgstr "يمكنك الدخول إلى مقررك على %(course_url)s."
-
-#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/subject.txt
-#: lms/templates/instructor/edx_ace/enrollenrolled/email/subject.txt
-#, python-format
-msgid "You have been enrolled in %(course_name)s"
-msgstr "لقد تم تسجيلك في %(course_name)s"
-
-#: lms/templates/instructor/edx_ace/addbetatester/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                    You have been invited to be a beta tester for %(course_name)s at %(site_name)s\n"
-"                "
-msgstr ""
-"\n"
-"لقد تمت دعوتك لتكون أحد مختبري الإصدار التجريبي ل%(course_name)sفي%(site_name)s"
 
 #: lms/templates/instructor/edx_ace/addbetatester/email/body.html
 msgid "The invitation has been sent by a member of the course staff."
@@ -867,11 +681,6 @@ msgstr "للبدء بالاطلاع على مواد المقرر، يُرجى ز
 #: lms/templates/instructor/edx_ace/addbetatester/email/body.html
 msgid "To enroll in this course and begin the beta test:"
 msgstr "للالتحاق بهذا المقرر والبدء في الاختبار التجريبي:"
-
-#: lms/templates/instructor/edx_ace/addbetatester/email/body.html
-#, python-format
-msgid "Visit %(course_name)s"
-msgstr "قم بزيارة %(course_name)s"
 
 #: lms/templates/instructor/edx_ace/addbetatester/email/body.txt
 #, python-format
@@ -900,16 +709,6 @@ msgstr ""
 msgid "Visit %(site_name)s to enroll in this course and begin the beta test."
 msgstr "قم بزيارة %(site_name)s للالتحاق بالمقرر والبدء في الاختبار التجريبي."
 
-#: lms/templates/instructor/edx_ace/addbetatester/email/subject.txt
-#, python-format
-msgid "You have been invited to a beta test for %(course_name)s"
-msgstr "لقد تمت دعوتك إلى اختبار تجريبي لـ %(course_name)s"
-
-#: lms/templates/instructor/edx_ace/allowedenroll/email/body.html
-#, python-format
-msgid "You have been invited to %(course_name)s"
-msgstr "لقد تمت دعوتك إلى %(course_name)s"
-
 #: lms/templates/instructor/edx_ace/allowedenroll/email/body.html
 #: lms/templates/instructor/edx_ace/allowedenroll/email/body.txt
 #, python-format
@@ -929,25 +728,10 @@ msgid "To access this course visit it and register:"
 msgstr "للدخول إلى هذا المقرر، يرجي زيارة الصفحة والالتحاق في المقرر:"
 
 #: lms/templates/instructor/edx_ace/allowedenroll/email/body.html
-#: lms/templates/instructor/edx_ace/allowedenroll/email/body.txt
-#, python-format
-msgid ""
-"Once you have registered and activated your account, you will see "
-"%(course_name)s listed on your dashboard."
-msgstr ""
-"بمجرد تسجيل حسابك وتنشيطه، سترى %(course_name)sمدرجة في لوحة معلوماتك."
-
-#: lms/templates/instructor/edx_ace/allowedenroll/email/body.html
 msgid ""
 "Once you have registered and activated your account, you will be able to "
 "access this course:"
 msgstr "بمجرد تسجيل حسابك وتفعيله، ستتمكن من الدخول إلى هذا المقرر:"
-
-#: lms/templates/instructor/edx_ace/allowedenroll/email/body.html
-#: lms/templates/instructor/edx_ace/allowedenroll/email/body.txt
-#, python-format
-msgid "You can then enroll in %(course_name)s."
-msgstr "يمكنك بعد ذلك التسجيل في %(course_name)s."
 
 #: lms/templates/instructor/edx_ace/allowedenroll/email/body.txt
 #, python-format
@@ -970,18 +754,6 @@ msgid ""
 msgstr ""
 "بمجرد تسجيل حسابك وتفعيله ، قم بزيارة %(course_about_url)s للالتحاق بالمقرر."
 
-#: lms/templates/instructor/edx_ace/allowedenroll/email/subject.txt
-#, python-format
-msgid "You have been invited to register for %(course_name)s"
-msgstr "لقد تمت دعوتك للتسجيل في %(course_name)s"
-
-#: lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
-#: lms/templates/instructor/edx_ace/allowedunenroll/email/subject.txt
-#: lms/templates/instructor/edx_ace/enrolledunenroll/email/subject.txt
-#, python-format
-msgid "You have been unenrolled from %(course_name)s"
-msgstr "لقد تم إلغاء تسجيلك من %(course_name)s"
-
 #: lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
 #: lms/templates/instructor/edx_ace/allowedunenroll/email/body.txt
 #, python-format
@@ -991,16 +763,6 @@ msgid ""
 msgstr ""
 "تم إلغاء تسجيلك من المقرر %(course_name)s بواسطة أحد أعضاء الطاقم. الرجاء "
 "تجاهل الدعوة المرسلة سابقا."
-
-#: lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                    You have been unenrolled from %(course_name)s\n"
-"                "
-msgstr ""
-"\n"
-"لقد تم إلغاء تسجيلك من %(course_name)s"
 
 #: lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
 #: lms/templates/instructor/edx_ace/enrolledunenroll/email/body.txt
@@ -1021,16 +783,6 @@ msgid "Your other courses have not been affected."
 msgstr "لم يؤثر ذلك على باقي المقررات."
 
 #: lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
-#, python-format
-msgid ""
-"\n"
-"                    You have been enrolled in %(course_name)s\n"
-"                "
-msgstr ""
-"\n"
-"لقد تم تسجيلك في %(course_name)s"
-
-#: lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
 #: lms/templates/instructor/edx_ace/enrollenrolled/email/body.txt
 #, python-format
 msgid ""
@@ -1044,12 +796,6 @@ msgstr ""
 #: lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
 msgid "Access the Course Materials Now"
 msgstr "احصل على حق الدخول إلى مواد المقرر الآن"
-
-#: lms/templates/instructor/edx_ace/removebetatester/email/body.html
-#, python-format
-msgid ""
-"You have been removed as a beta tester for %(course_name)s at %(site_name)s"
-msgstr "لقد تمت إزالتك كمختبِر تجريبي لـ %(course_name)sفي %(site_name)s"
 
 #: lms/templates/instructor/edx_ace/removebetatester/email/body.html
 #, python-format
@@ -1079,11 +825,6 @@ msgstr ""
 "أعضاء فريق طاقم المقرر. سيبقى هذا المقرر في لوحة المعلومات الخاصة بك، لكنك "
 "لن تكون جزءًا من مجموعة الاختبار التجريبي."
 
-#: lms/templates/instructor/edx_ace/removebetatester/email/subject.txt
-#, python-format
-msgid "You have been removed from a beta test for %(course_name)s"
-msgstr "لقد تمت إزالتك من الاختبار التجريبي لـ %(course_name)s"
-
 #: lms/templates/oauth2_provider/authorize.html
 msgid ""
 "These permissions will be granted for data from your courses associated with"
@@ -1098,6 +839,10 @@ msgstr ""
 msgid "View Course"
 msgstr "عرض المقرر"
 
+#: lms/templates/save_for_later/edx_ace/saveforlater/email/body.html
+msgid "Self-paced"
+msgstr "مقرر دائم"
+
 #: openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
 #: cms/templates/index.html lms/templates/courseware/courses.html
 #: lms/templates/header/navbar-authenticated.html
@@ -1107,27 +852,6 @@ msgstr "عرض المقرر"
 #: lms/templates/navigation/navbar-not-authenticated.html
 msgid "Courses"
 msgstr "مقررات"
-
-#: openedx/core/djangoapps/bookmarks/views.py
-#, python-brace-format
-msgid ""
-"You can create up to {max_num_bookmarks_per_course} bookmarks. You must "
-"remove some bookmarks before you can add new ones."
-msgstr ""
-"يمكنك إنشاء {max_num_bookmarks_per_course} علامة على الأكثر. يجب حذف بعض "
-"العلامات قبل السماح بإضافة علامات جديدة."
-
-#: openedx/core/djangoapps/catalog/models.py
-msgid "DEPRECATED: Use the setting COURSE_CATALOG_API_URL."
-msgstr "مهمل: استخدم الإعداد COURSE_CATALOG_API_URL."
-
-#: openedx/core/djangoapps/catalog/models.py
-msgid ""
-"Username created for Course Catalog Integration, e.g. "
-"lms_catalog_service_user."
-msgstr ""
-"تم إنشاء اسم المستخدم لدمج كتالوج الدورة التعليمية، على سبيل المثال، "
-"lms_catalog_service_user."
 
 #: openedx/core/djangoapps/config_model_utils/admin.py
 #, python-brace-format
@@ -1158,11 +882,6 @@ msgstr ""
 "وقت التشغيل من السياق التالي الأكثر تحديدًا الذي ينطبق. على سبيل المثال، إذا"
 " تم ترك \"ممكّن\" كـ \"غير معروف\" في سياق المقرر، فلن يتم تمكين هذا المقرر "
 "إلا إذا تم تمكين المؤسسة الموجودة فيها."
-
-#: openedx/core/djangoapps/config_model_utils/models.py
-#, python-format
-msgid "%(value)s should have the form ORG+COURSE"
-msgstr "%(value)s يجب أن يكون على شكل ORG + COURSE"
 
 #: openedx/core/djangoapps/config_model_utils/models.py
 msgid "Configure values for all course runs associated with this site."
@@ -1237,13 +956,6 @@ msgstr ""
 "البريد الإلكتروني المرسَلة بخصوص إيصال دفعة الوحدة الدراسية والتي تُرسل "
 "\"بعد\" سداد القيمة لتلقّي اعتماد مادّة مقرر ذا وحدات دراسية معتمدة."
 
-#: openedx/core/djangoapps/discussions/models.py
-msgid ""
-"If disabled, the discussions in the associated learning context/course will "
-"be disabled."
-msgstr ""
-"إذا تم تعطيله، فسيتم تعطيل المناقشات في سياق / برنامج التعلم ذي الصلة."
-
 #: openedx/core/djangoapps/discussions/plugins.py
 msgid ""
 "Encourage participation and engagement in your course with discussions."
@@ -1314,21 +1026,6 @@ msgid "Course ID"
 msgstr "الرقم التعريفي للمقرر"
 
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/body.html
-#, python-format
-msgid "Welcome to week %(week_num)s of %(course_name)s!"
-msgstr "مرحبًا بك في الأسبوع %(week_num)s من %(course_name)s!"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
-#, python-brace-format
-msgid ""
-"We hope you're enjoying {start_strong}{course_name}{end_strong}! We want to "
-"let you know what you can look forward to in week {week_num}:"
-msgstr ""
-"نأمل أن تكون مستمتعًا بـ {start_strong} {course_name} {end_strong}! نريد "
-"إخبارك بما يمكنك أن تتطلع إليه في الأسبوع {week_num}:"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
 msgid ""
 "With self-paced courses, you learn on your own schedule. We encourage you to"
@@ -1344,24 +1041,6 @@ msgstr ""
 msgid "Resume your course now"
 msgstr "استئناف المقرر الآن"
 
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
-#, python-format
-msgid ""
-"We hope you're enjoying %(course_name)s! We want to let you know what you "
-"can look forward to in week %(week_num)s:"
-msgstr ""
-"نأمل أن تستمتع بـ %(course_name)s! نريد أن نخبرك بما يمكنك التطلع إليه في "
-"الأسبوع %(week_num)s:"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/body.html
-#, python-brace-format
-msgid ""
-"We hope you're enjoying {start_strong}{course_name}{end_strong}! We want to "
-"let you know what you can look forward to in the coming weeks:"
-msgstr ""
-"نأمل أن تكون مستمتعًا بـ {start_strong} {course_name} {end_strong}! نود "
-"إخبارك بما يمكنك أن تتطلع إليه في الأسابيع القادمة:"
-
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/body.html
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/body.txt
 msgid ""
@@ -1370,20 +1049,6 @@ msgid ""
 msgstr ""
 "نحن نشجعك على قضاء الوقت مع المقرر بشكل أسبوعي. تركيزك سيؤتي ثماره في "
 "النهاية!"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/body.txt
-#, python-format
-msgid ""
-"We hope you're enjoying %(course_name)s! We want to let you know what you "
-"can look forward to in the coming weeks:"
-msgstr ""
-"نأمل أن  تكون%(course_name)s ممتعة! نود إخبارك بما يمكنك أن تتطلع إليه في "
-"الأسابيع القادمة:"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/instructorledcourseupdate/email/subject.txt
-#, python-format
-msgid "%(course_name)s Weekly Update"
-msgstr "تحديث اسبوعي ل%(course_name)s"
 
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.html
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.txt
@@ -1396,17 +1061,6 @@ msgstr ""
 "يقوم العديد من متعلمي %(platform_name)s في مقرر %(course_name)s بإتمام "
 "المزيد من المسائل كل أسبوع، والمشاركة في منتديات المحادثة. ماذا تريد أن تفعل"
 " أنت للحفاظ على نسق الدراسة؟"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.html
-#, python-brace-format
-msgid ""
-"Many {platform_name} learners in {start_strong}{course_name}{end_strong} are"
-" completing more problems every week, and participating in the discussion "
-"forums. What do you want to do to keep learning?"
-msgstr ""
-"يكمل العديد من متعلمي {platform_name} في {start_strong} {course_name} "
-"{end_strong} المزيد من المسائل كل أسبوع، ويشاركون في منتديات المناقشة. ماذا "
-"تريد أن تفعل لمواصلة التعلم؟"
 
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
@@ -1421,17 +1075,6 @@ msgstr ""
 "نعم ، نحن سعداء بوجودك! تعال واطلع على ما يتعلمه الجميع."
 
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
-#: themes/red-theme/lms/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
-#, python-format
-msgid ""
-"Remember when you enrolled in %(course_name)s on %(platform_name)s? We do, "
-"and we’re glad to have you! Come see what everyone is learning."
-msgstr ""
-"هل تذكر عندما سجلت في %(course_name)s على %(platform_name)s؟ نعم ، نحن سعداء"
-" بوجودك! تعال واطلع على ما يتعلمه الجميع."
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
 #, python-brace-format
 msgid ""
 "Remember when you enrolled in {start_strong}{course_name}{end_strong}, and "
@@ -1442,57 +1085,17 @@ msgstr ""
 "أخرى على {platform_name}؟ نحن نتذكر ، ويسعدنا أن تكون معنا! تعال واطلع على "
 "ما يتعلمه الجميع."
 
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
-#, python-brace-format
-msgid ""
-"Remember when you enrolled in {start_strong}{course_name}{end_strong} on "
-"{platform_name}? We do, and we’re glad to have you! Come see what everyone "
-"is learning."
-msgstr ""
-"هل تتذكر عندما سجلت في {start_strong} {course_name} {end_strong} على "
-"{platform_name}؟ نحن نتذكر، ويسعدنا أن تكون معنا! تعال واطلع على ما يتعلمه "
-"الجميع."
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/subject.txt
-#, python-format
-msgid "Keep learning in %(course_name)s"
-msgstr "واصل التعلّم في %(course_name)s"
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.txt
-#, python-format
-msgid ""
-"We hope you are enjoying learning with us so far in %(first_course_name)s! A"
-" verified certificate allows you to highlight your new knowledge and skills."
-" An %(platform_name)s certificate is official and easily shareable. Upgrade "
-"by %(user_schedule_upgrade_deadline_time)s."
-msgstr ""
-"نأمل أن تستمتع بالتعلم معنا حتى الآن في %(first_course_name)s! تتيح لك "
-"الشهادة التي تم التحقق منها إبراز معارفك ومهاراتك الجديدة. شهادة "
-"%(platform_name)s هي رسمية ويمكن مشاركتها بسهولة. قم بالترقية قبل "
-"%(user_schedule_upgrade_deadline_time)s."
-
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
-#, python-brace-format
-msgid ""
-"We hope you are enjoying learning with us so far in "
-"{start_strong}{first_course_name}{end_strong}! A verified certificate allows"
-" you to highlight your new knowledge and skills. An {platform_name} "
-"certificate is official and easily shareable."
-msgstr ""
-"نأمل أن تكون مستمتعًا بالتعلم معنا حتى الآن في {start_strong} "
-"{first_course_name} {end_strong}! تتيح لك الشهادة التي تم التحقق منها إبراز "
-"معرفتك ومهاراتك الجديدة. شهادة {platform_name} هي شهادة رسمية ويمكن مشاركتها"
-" بسهولة."
-
 #: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
 msgid "You are eligible to upgrade in these courses:"
 msgstr "أنت مؤهل للترقية في هذه المقررات:"
 
-#: openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/subject.txt
-#, python-format
-msgid "Upgrade to earn a verified certificate in %(first_course_name)s"
-msgstr "قم بالترقية للحصول على شهادة معتمدة في %(first_course_name)s"
+#: openedx/core/djangoapps/user_api/accounts/views.py
+msgid ""
+"This account has been temporarily locked due to excessive login failures. "
+"Try again later."
+msgstr ""
+"أُغلِقَ هذا الحساب موقوتًا نتيجة عدّة محاولات فاشلة لتسجيل الدخول. يُرجى "
+"إعادة المحاولة لاحقًا."
 
 #. Translators: These instructions appear on the registration form,
 #. immediately
@@ -1501,26 +1104,6 @@ msgstr "قم بالترقية للحصول على شهادة معتمدة في %
 msgid ""
 "The name that will identify you in your courses. It cannot be changed later."
 msgstr "الاسم الذي سيعرّفك في المقررات. لا يمكن تغييره لاحقا."
-
-#: openedx/features/calendar_sync/ics.py
-#, python-brace-format
-msgid "{assignment} is due for {course}."
-msgstr "{assignment} مستحقة لـ {course}."
-
-#: openedx/features/calendar_sync/utils.py
-#, python-brace-format
-msgid "Sync {course} to your calendar"
-msgstr "مزامنة  {course} إلى تقويمك"
-
-#: openedx/features/calendar_sync/utils.py
-#, python-brace-format
-msgid ""
-"Sticking to a schedule is the best way to ensure that you successfully "
-"complete your self-paced course. This schedule for {course} will help you "
-"stay on track!"
-msgstr ""
-"إن الالتزام بجدول زمني هو أفضل طريقة لضمان إكمال الدورة التدريبية الخاصة بك "
-"بنجاح. سيساعدك هذا الجدول الزمني لـ {course} في البقاء على المسار الصحيح!"
 
 #: openedx/features/calendar_sync/utils.py
 msgid ""
@@ -1532,20 +1115,10 @@ msgstr ""
 "معلمك. يمكنك إزالة المقرر من التقويم في أي وقت."
 
 #: openedx/features/calendar_sync/utils.py
-#, python-brace-format
-msgid "{course} dates have been updated on your calendar"
-msgstr "تم تحديث تواريخ {course} في التقويم"
-
-#: openedx/features/calendar_sync/utils.py
 msgid ""
 "You have successfully shifted your course schedule and your calendar is up "
 "to date."
 msgstr "لقد قمت بنقل جدول مقررك بنجاح والتقويم محدّث."
-
-#: openedx/features/course_duration_limits/access.py
-#, python-brace-format
-msgid "Access to {course_name} expired on {expiration_date}"
-msgstr "حق الدخول الى {course_name} انتهت صلاحيته في {expiration_date}"
 
 #: openedx/features/course_duration_limits/access.py
 #, python-brace-format
@@ -1585,10 +1158,6 @@ msgstr ""
 "{sronly_span_open} للاحتفاظ بحق الدخول بعد {expiration_date} {span_close} "
 "{a_close}"
 
-#: openedx/features/course_experience/api/v1/views.py
-msgid "'course_key' is required."
-msgstr "'course_key' مطلوب."
-
 #: openedx/features/discounts/admin.py
 msgid ""
 "These define the context to disable lms-controlled discounts on. If no "
@@ -1619,38 +1188,39 @@ msgstr ""
 "التحديد، وللمؤسسة التي يوجد بها المقرر، فإن السياق الأكثر تحديدًا يتجاوز "
 "السياق العام."
 
-#: openedx/features/enterprise_support/admin/forms.py
-msgid ""
-"CSV file should have 3 columns having names lms_user_id, course_id, "
-"opportunity_id"
-msgstr ""
-"يجب أن يحتوي ملف CSV على 3 أعمدة تحتوي على العناوين LMS_USER_id، course_id، "
-"opportunity_id"
-
-#: openedx/features/enterprise_support/api.py
-#, python-brace-format
-msgid ""
-"You have access to the {bold_start}{enterprise_name}{bold_end} dashboard. To"
-" access the courses available to you through {enterprise_name}, "
-"{link_start}visit the {enterprise_name} dashboard{link_end}."
-msgstr ""
-"يمكنك الوصول إلى لوحة تحكم {bold_start} {enterprise_name} {bold_end}. للوصول"
-" إلى الدورات التدريبية المتاحة لك من خلال {enterprise_name} ، {link_start} "
-"قم بزيارة {enterprise_name} لوحة التحكم {link_end}."
-
-#: openedx/features/enterprise_support/api.py
-#, python-brace-format
-msgid "Enrollment in {course_title} was not complete."
-msgstr "لم يكتمل التسجيل في {course_title}."
-
 #: openedx/features/enterprise_support/templates/enterprise_support/admin/enrollment_attributes_override.html
 msgid "Enterprise Course Enrollments"
 msgstr "التحاق المجموعات في المقرر"
+
+#: xmodule/capa/responsetypes.py
+msgid "There was a problem with the staff answer to this problem."
+msgstr "حدثت مشكلة في إجابة طاقم المقرر على هذه المسألة."
+
+#. Translators: This is an error message for a math problem. If the instructor
+#. provided a
+#. boundary (end limit) for a variable that is a complex number (a + bi), this
+#. message displays.
+#: xmodule/capa/responsetypes.py
+msgid ""
+"There was a problem with the staff answer to this problem: complex boundary."
+msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المقرر عن هذه المسألة: حدود مركّبة."
+
+#. Translators: This is an error message for a math problem. If the instructor
+#. did not
+#. provide a boundary (end limit) for a variable, this message displays.
+#: xmodule/capa/responsetypes.py
+msgid ""
+"There was a problem with the staff answer to this problem: empty boundary."
+msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المقرر عن هذه المسألة: حدود خالية."
 
 #. Translators: 'grader' refers to the edX automatic code grader.
 #: xmodule/capa/responsetypes.py
 msgid "Invalid grader reply. Please contact the course staff."
 msgstr "إجابة مُقيّم غير صحيحة. يُرجى الاتصال بطاقم المقرر."
+
+#: xmodule/capa/responsetypes.py
+msgid "The Staff answer could not be interpreted as a number."
+msgstr "تعذّر تفسير إجابة طاقم المقرر كعدد."
 
 #: xmodule/capa_block.py
 msgid ""
@@ -1704,20 +1274,6 @@ msgstr ""
 "هذا."
 
 #: xmodule/course_block.py
-msgid "Course Advertised Start"
-msgstr "الإعلان عن بدء الدورة التعليمية"
-
-#: xmodule/course_block.py
-msgid ""
-"Enter the text that you want to use as the advertised starting time frame "
-"for the course, such as \"Winter 2018\". If you enter null for this value, "
-"the start date that you have set for this course is used."
-msgstr ""
-"أدخل النص الذي تريد استخدامه كالإطار الزمني المعلن لبداية الدورة، مثل \"شتاء"
-" 2018\". إذا تركت هذه القيمة فارغة، سيتم استخدام تاريخ البدء الذي قمت بضبطه "
-"لهذه الدورة."
-
-#: xmodule/course_block.py
 msgid "Pre-Requisite Courses"
 msgstr "مقررات أساسية"
 
@@ -1756,27 +1312,6 @@ msgid ""
 msgstr ""
 "يُرجى إدخال الرابط الخاص باستبيان نهاية المقرر. في حال لم يستوجب مقررك "
 "الإدلاء باستبيان، يُرجى إدخال القيمة ’null‘. "
-
-#: xmodule/course_block.py
-msgid ""
-"Enter discussion categories in the following format: \"CategoryName\": "
-"{\"id\": \"i4x-InstitutionName-CourseNumber-course-CourseRun\"}. For "
-"example, one discussion category may be \"Lydian Mode\": {\"id\": "
-"\"i4x-UniversityX-MUS101-course-2015_T1\"}. The \"id\" value for each "
-"category must be unique. In \"id\" values, the only special characters that "
-"are supported are underscore, hyphen, and period. You can also specify a "
-"category as the default for new posts in the Discussion page by setting its "
-"\"default\" attribute to true. For example, \"Lydian Mode\": {\"id\": "
-"\"i4x-UniversityX-MUS101-course-2015_T1\", \"default\": true}."
-msgstr ""
-"أدخل فئات المناقشة بالصيغة التالية: \"CategoryName\": {\"id\": "
-"\"i4x-InstitutionName-CourseNumber-course-CourseRun\"}. على سبيل المثال، قد "
-"تكون فئة مناقشة هي \"Lydian Mode\": {\"id\": \"i4x-UniversityX-"
-"MUS101-course-2015_T1\"}. يجب أن تكون قيمة \"id\" لكل فئة فريدة. في قيم "
-"\"id\"، الأحرف الخاصة الوحيدة التي يتم دعمها هي تسطير سفلي و مطّة ونقطة. "
-"يمكنك أيضا تحديد فئة منها كفئة افتراضية للمشاركات الجديدة في صفحة المناقشة "
-"عن طريق تعيين السمة \"default\" إلى صحيح. على سبيل المثال،  \"Lydian Mode\":"
-" {\"id\": \"i4x-UniversityX-MUS101-course-2015_T1\", \"default\": true}."
 
 #: xmodule/course_block.py
 msgid "Course Announcement Date"
@@ -1841,10 +1376,6 @@ msgstr ""
 "إخفاء هويّة الطالب الناشر عن طاقم المقرر."
 
 #: xmodule/course_block.py
-msgid "Enter the names of the advanced modules to use in your course."
-msgstr "أدخل أسماء الوحدات المتقدمة لاستخدامها في دورتك التدريبية."
-
-#: xmodule/course_block.py
 msgid ""
 "True if timezones should be shown on dates in the course. Deprecated in "
 "favor of due_date_display_format."
@@ -1857,6 +1388,10 @@ msgid "Enter the external login method students can use for the course."
 msgstr ""
 "يُرجى إدخال الطريقة الخارجية لتسجيل الدخول والتي يمكن للطلّاب استخدامها في "
 "المقرر."
+
+#: xmodule/course_block.py
+msgid "Certificates Downloadable Before End"
+msgstr "الشهادات القابلة للتنزيل قبل انتهاء المقرر"
 
 #: xmodule/course_block.py
 msgid ""
@@ -1879,14 +1414,6 @@ msgstr ""
 "تعديل اسم ملف صورة المقرر. يُرجى تحميل هذا الملف على صفحة \"الملفات "
 "والتحميلات\". كما ويمكنك أيضًا ضبط صورة المقرر على صفحة \"الإعدادات "
 "والتفاصيل\"."
-
-#: xmodule/course_block.py cms/templates/settings.html
-msgid "Course Banner Image"
-msgstr "صورة شعار الدورة التدريبية"
-
-#: xmodule/course_block.py cms/templates/settings.html
-msgid "Course Video Thumbnail Image"
-msgstr "صورة الفيديو المصغرة للدورة التدريبية"
 
 #: xmodule/course_block.py
 msgid ""
@@ -1920,6 +1447,12 @@ msgid "If true, certificate Web/HTML views are enabled for the course."
 msgstr ""
 "في حال ’true‘ـ يجري تفعيل خاصيّة استعراض شهادة هذا المقرر على شكل صفحة ويب "
 "أو بصيغة HTML."
+
+#. Translators: This field is the container for course-specific certificate
+#. configuration values
+#: xmodule/course_block.py
+msgid "Certificate Web/HTML View Overrides"
+msgstr "تجاوز مشاهدة صفحة الويب/html للمقرر"
 
 #. Translators: These overrides allow for an alternative configuration of the
 #. certificate web view
@@ -2080,20 +1613,6 @@ msgstr "حدّد لغة المقرر"
 
 #: xmodule/course_block.py
 msgid ""
-"Configure team sets, limit team sizes, and set visibility settings using "
-"JSON. See <a target=\"&#95;blank\" "
-"href=\"https://edx.readthedocs.io/projects/edx-partner-course-"
-"staff/en/latest/course_features/teams/teams_setup.html#enable-and-configure-"
-"teams\">teams configuration documentation</a> for help and examples."
-msgstr ""
-"قم بتشكيل مجموعات الفريق وتحديد أحجام الفريق وتعيين إعدادات الرؤية باستخدام "
-"JSON. راجع<a target=\"&#95;blank\" "
-"href=\"https://edx.readthedocs.io/projects/edx-partner-course-"
-"staff/en/latest/course_features/teams/teams_setup.html#enable-and-configure-"
-"teams\">وثائق تكوين الفِرق </a>للحصول على التعليمات والأمثلة."
-
-#: xmodule/course_block.py
-msgid ""
 "Enter true or false. If this value is true, proctored exams are enabled in "
 "your course. Note that enabling proctored exams will also enable timed "
 "exams."
@@ -2113,28 +1632,6 @@ msgstr ""
 
 #: xmodule/course_block.py
 msgid ""
-"Enter true or false. If this value is true, learners can choose to take "
-"proctored exams without proctoring. If this value is false, all learners "
-"must take the exam with proctoring. This setting only applies if proctored "
-"exams are enabled for the course."
-msgstr ""
-"أدخل صحيح أو خاطئ. إذا كان الخيار صحيح، سيتم تفعيل الامتحانات المُراقبة دون "
-"مراقبة. إذا كان هذا الخيار خاطئ يجب على كل الطلاب الخضوع للامتحان تحت "
-"الرقابة. يتم تفعيل هذا الإعداد فقط إذا تم تحديد خيار تفعيل الامتحانات "
-"المُراقبة في الدورة."
-
-#: xmodule/course_block.py
-msgid ""
-"Enter true or false. If this value is true, timed exams are enabled in your "
-"course. Regardless of this setting, timed exams are enabled if Enable "
-"Proctored Exams is set to true."
-msgstr ""
-"أدخل صحيح أو خاطئ. إذا كان الخيار صحيح، سيتم تفعيل الامتحانات الموقته في "
-"دورتك. بغض النظر عن هذا الإعداد، يتم تفعيل الامتحانات الموقتة إذا تم تحديد "
-"خيار تفعيل الامتحانات الموقتة."
-
-#: xmodule/course_block.py
-msgid ""
 "The minimum grade that a learner must earn to receive credit in the course, "
 "as a decimal between 0.0 and 1.0. For example, for 75%, enter 0.75."
 msgstr ""
@@ -2151,18 +1648,6 @@ msgstr ""
 " في مقررات التعلّم الذاتي، تاريخ لتسليم الفروض كما ويُسمح للمتعلّمين التقدّم"
 " في مواد  المقرر بأي سرعة وفي أي وقت يسبق نهاية المقرر."
 
-#: xmodule/course_block.py
-msgid "Course Learning Information"
-msgstr "معلومات عن تعلم الدورة التدريبية"
-
-#: xmodule/course_block.py
-msgid "Specify what student can learn from the course."
-msgstr "حدد ما يمكن أن يتعلمه الطلاب في هذه الدورة التدريبية."
-
-#: xmodule/course_block.py
-msgid "Course Visibility For Unenrolled Learners"
-msgstr "إمكانية مشاهدة الدورة للمتعلمين غير المسجلين"
-
 #. Translators: the quoted words 'private', 'public_outline', and 'public'
 #. must be left untranslated.  Leave them as English words.
 #: xmodule/course_block.py
@@ -2176,27 +1661,6 @@ msgstr ""
 " الخيارات الثلاث: \"خاص\" (إمكانية مشاهدة افتراضية ، مسموح بها فقط للمتعلمين"
 " الملتحقين) ، \"مخطط_عام\" (السماح بالوصول إلى مخطط المقرر) و \"عام\" "
 "(السماح بالوصول إلى كل من المخطط ومحتوى المقرر)."
-
-#: xmodule/course_block.py
-msgid "Course Instructor"
-msgstr "مدرّس الدورة التدريبية"
-
-#: xmodule/course_block.py
-msgid "Enter the details for Course Instructor"
-msgstr "أدخل معلومات مدرس الدورة التدريبية"
-
-#: xmodule/course_block.py
-msgid ""
-"Enter true or false. If true, you can add unsupported problems and tools to "
-"your course in Studio. Unsupported problems and tools are not recommended "
-"for use in courses due to non-compliance with one or more of the base "
-"requirements, such as testing, accessibility, internationalization, and "
-"documentation."
-msgstr ""
-"أدخل صح أو خطأ. في حالة صح، يمكنك إضافة المسائل والأدوات غير المدعومة لدورتك"
-" التدريبية في Studio. لا ينصح باستخدام المسائل والأدوات غير المدعومة في "
-"دورتك التدريبية بسبب عدم الامتثال مع واحد أو أكثر من الشروط الأساسية، مثل "
-"الاختبار وسهولة الوصول والتدويل والتوثيق."
 
 #: xmodule/course_block.py
 msgid ""
@@ -2249,14 +1713,6 @@ msgstr ""
 "{register_link} ، والتسجيل في هذا المقرر."
 
 #: xmodule/html_block.py
-msgid ""
-"If you select this option, only course team members with the Staff or Admin "
-"role see this page."
-msgstr ""
-"إذا قمت بتحديد هذا الخيار، سيتمكن أعضاء فريق الدورة من المشرفين والطاقم فقط "
-"برؤية هذه الصفحة."
-
-#: xmodule/html_block.py
 msgid "List of course update items"
 msgstr "لائحة بعناصر تحديث المقرر"
 
@@ -2267,6 +1723,10 @@ msgid ""
 msgstr ""
 "لا يدعم هذا المقرر مكتبات محتوى. يُرجى الاتّصال بمسؤول النظام للحصول على "
 "مزيد من المعلومات."
+
+#: xmodule/library_content_block.py
+msgid "Edit the library configuration."
+msgstr "تعديل إعدادات المقرر"
 
 #: xmodule/modulestore/inheritance.py
 msgid "Enter the URL for the course data GIT repository."
@@ -2407,14 +1867,6 @@ msgstr ""
 "يجري الغاء عملبة لاستيراد لان مقرر مع رقم التعريف هذا :{} موجود بالفغل"
 
 #: cms/djangoapps/contentstore/git_export_utils.py
-msgid ""
-"If using http urls, you must provide the username and password in the url. "
-"Similar to https://user:pass@github.com/user/course."
-msgstr ""
-"في حال استخدام الروابط وفق بروتوكول http، فإنّه يجب ذكر اسم المستخدم وكلمة "
-"المرور في الرابط، كما يلي https://user:pass@github.com/user/course."
-
-#: cms/djangoapps/contentstore/git_export_utils.py
 msgid "Unable to export course to xml."
 msgstr "تعذّر تصدير المقرر إلى ملف بصيغة xml."
 
@@ -2497,13 +1949,6 @@ msgstr "استُكمِل امتحان دخول المقرر"
 msgid "Course successfully exported to git repository"
 msgstr "جرى بنجاح تصدير المقرر إلى مستودع git"
 
-#. Translators: This is the suggested filename when downloading the URL
-#. listing for videos uploaded through Studio
-#: cms/djangoapps/contentstore/views/videos.py
-#, python-brace-format
-msgid "{course}_video_urls"
-msgstr "{course}_video_urls"
-
 #: cms/djangoapps/course_creators/models.py
 msgid "Current course creator state"
 msgstr "الحالة الحالية لمُنشئ المقرر "
@@ -2514,43 +1959,6 @@ msgid ""
 "denied)"
 msgstr ""
 "ملاحظات اختيارية حول هذا المستخدم (لماذا مثلًا رُفض طلب الدخول لإنشاء مقرر)"
-
-#: cms/djangoapps/maintenance/views.py
-#: cms/templates/maintenance/_force_publish_course.html
-msgid "Force Publish Course"
-msgstr "تنفيذ نشر الدورة التدريبية"
-
-#: cms/djangoapps/maintenance/views.py
-msgid ""
-"Sometimes the draft and published branches of a course can get out of sync. "
-"Force publish course command resets the published branch of a course to "
-"point to the draft branch, effectively force publishing the course. This "
-"view dry runs the force publish command"
-msgstr ""
-"في بعض الأحيان، تكون الفروع المنشورة ومسودات الدورة التدريبية غير متزامنة. "
-"يقوم أمر التنفيذ بنشر الدورة التدريبية بإعادة تعيين الفرع المنشور للدورة "
-"التدريبية للإشارة إلى فرع المسودة، مما ينفذ النشر للدورة بشكل فعال. يقدم هذا"
-" العرض اختبارًا تجريبيًا لأمر تنفيذ النشر"
-
-#: cms/djangoapps/maintenance/views.py
-msgid "Please provide course id."
-msgstr "يرجى تقديم معرف للدورة التدريبية."
-
-#: cms/djangoapps/maintenance/views.py
-msgid "Invalid course key."
-msgstr "مفتاح الدورة التدريبية غير صالح."
-
-#: cms/djangoapps/maintenance/views.py
-msgid "No matching course found."
-msgstr "لم يتم العثور على دورة تدريبية مطابقة."
-
-#: cms/djangoapps/maintenance/views.py
-msgid "Force publishing course is not supported with old mongo courses."
-msgstr "تنفيذ نشر الدورة التدريبية غير مدعوم مع الدورات التدريبية القديمة. "
-
-#: cms/djangoapps/maintenance/views.py
-msgid "Course is already in published state."
-msgstr "الدورة التدريبية في حالة نشر بالفعل."
 
 #: cms/templates/course-create-rerun.html cms/templates/index.html
 #: lms/templates/support/feature_based_enrollments.html
@@ -2572,13 +1980,13 @@ msgstr "رقم المقرر: "
 msgid "Course Run:"
 msgstr "تشغيل المقرر:"
 
+#: cms/templates/settings.html lms/templates/courseware/program_marketing.html
+msgid "Instructors"
+msgstr "أساتذة المقرر"
+
 #: lms/templates/courses_list.html
 msgid "View all Courses"
 msgstr "عرض جميع المقررات"
-
-#: lms/templates/dashboard.html
-msgid "Click to load all enrolled courses"
-msgstr "أنقر لتحميل جميع الدورات الملتحق بها"
 
 #: lms/templates/dashboard.html
 msgid "You are not enrolled in any courses yet."
@@ -2612,10 +2020,6 @@ msgid "Course: "
 msgstr "المقرر:"
 
 #: lms/templates/hidden_content.html
-msgid "The course has ended."
-msgstr "انتهت هذه الدورة التعليمية."
-
-#: lms/templates/hidden_content.html
 msgid ""
 "Because the course has ended, this assignment is no longer "
 "available.{line_break}If you have completed this assignment, your grade is "
@@ -2637,6 +2041,11 @@ msgstr "استعراض المقرر"
 msgid "View this course as:"
 msgstr "مشاهدة هذا المقرر كـ:"
 
+#: lms/templates/instructor/instructor_dashboard_2/membership.html
+#: lms/templates/preview_menu.html
+msgid "Staff"
+msgstr "طاقم المقرر"
+
 #: lms/templates/preview_menu.html
 msgid "You are now viewing the course as {i_start}{user_name}{i_end}."
 msgstr "أنت الآن تستعرض المقرر بصفتك {i_start}{user_name}{i_end}."
@@ -2655,6 +2064,14 @@ msgid ""
 msgstr ""
 "تم تنشيط بريدك الإلكتروني الثانوي. يرجى زيارة {link_start} لوحة المعلومات "
 "{link_end} للمقررات."
+
+#: lms/templates/staff_problem_info.html
+msgid "Staff Debug Info"
+msgstr "المعلومات حول تصحيح أخطاء طاقم المقرر"
+
+#: lms/templates/staff_problem_info.html
+msgid "Staff Debug:"
+msgstr "تصحيح طاقم المقرر:"
 
 #: lms/templates/static_htmlbook.html lms/templates/static_pdfbook.html
 #: lms/templates/staticbook.html
@@ -2707,88 +2124,6 @@ msgstr ""
 "الأسئلة التي تدور حول استخدام واجهة برمجة التطبيقات هذه، اتصل "
 "ب{api_support_email_link}."
 
-#: lms/templates/api_admin/terms_of_service.html
-msgid ""
-"Welcome to {platform_name}. Thank you for using {platform_name}'s Course "
-"Discovery API, Enterprise API and/or any additional APIs that we may offer "
-"from time to time (collectively, the \"APIs\"). Please read these Terms of "
-"Service prior to accessing or using the APIs. These Terms of Service, any "
-"additional terms within accompanying API documentation, and any applicable "
-"policies and guidelines that {platform_name} makes available and/or updates "
-"from time to time are agreements (collectively, the \"Terms\") between you "
-"and {platform_name}. These Terms are issued under the enterprise product "
-"agreement, member participation agreement, or other direct agreement "
-"governing the purchase of {platform_name} products, if any (the "
-"\"Agreement\"), executed by you or the party on whose behalf you are "
-"accessing or using the APIs and {platform_name}.  In the event that you have"
-" such an Agreement that applies to your use of the APIs, the Agreement will "
-"control in the event of any conflict between it and these Terms. By "
-"accessing or using the APIs, you accept and agree to be legally bound by the"
-" Terms, whether or not you are a registered user. If you are accessing or "
-"using the APIs on behalf of a company, organization or other legal entity, "
-"you are agreeing to these Terms for that entity and representing and "
-"warranting to {platform_name} that you have full authority to accept and "
-"agree to these Terms for such entity, in which case the terms \"you,\" "
-"\"your\" or related terms herein shall refer to such entity on whose behalf "
-"you are accessing or using the APIs. If you do not have such authority or if"
-" you do not understand or do not wish to be bound by the Terms, you should "
-"not use the APIs."
-msgstr ""
-"مرحباً بك في {platform_name}. نشكرك على استخدام واجهة برمجة تطبيقات "
-"Discovery API في {platform_name} و / أو واجهة برمجة تطبيقات للمؤسسات و / أو "
-"أي واجهات برمجة تطبيقات إضافية قد نقدمها من وقت لآخر (بشكل جماعي ، \"واجهات "
-"برمجة التطبيقات\"). يرجى قراءة شروط الخدمة هذه قبل الوصول إلى واجهات برمجة "
-"التطبيقات أو استخدامها. شروط الخدمة هذه ، وأي شروط إضافية ضمن وثائق واجهة "
-"برمجة التطبيقات المصاحبة ، وأي سياسات وإرشادات سارية توفرها {platform_name} "
-"و / أو تحديثات من وقت لآخر هي اتفاقيات (يُشار إليها إجمالاً باسم \"الشروط\")"
-" بينك وبين {platform_name}. يتم إصدار هذه الشروط بموجب اتفاقية منتج المؤسسة "
-"، أو اتفاقية مشاركة الأعضاء ، أو اتفاقية مباشرة أخرى تنظم شراء منتجات "
-"{platform_name} ، إن وجدت (\"الاتفاقية\") ، التي تنفذها أنت أو الطرف الذي "
-"تقوم بالوصول إليه أو تستخدمه واجهات برمجة التطبيقات و {platform_name}. في "
-"حالة وجود مثل هذه الاتفاقية التي تنطبق على استخدامك لواجهات برمجة التطبيقات "
-"، ستتحكم الاتفاقية في حالة وجود أي تعارض بينها وبين هذه الشروط. من خلال "
-"الوصول إلى واجهات برمجة التطبيقات أو استخدامها ، فإنك تقبل وتوافق على "
-"الالتزام القانوني بالشروط ، سواء كنت مستخدماً مسجلاً أم لا. إذا كنت تدخل إلى"
-" APIs أو تستخدمها نيابة عن شركة أو مؤسسة أو كيان قانوني آخر ، فأنت توافق على"
-" هذه الشروط لذلك الكيان وتقر وتضمن لـ {platform_name} أن لديك السلطة الكاملة"
-" لقبول هذه الشروط والموافقة عليها هذا الكيان ، وفي هذه الحالة ، تشير "
-"المصطلحات \"أنت\" و \"الخاصة بك\" أو المصطلحات ذات الصلة هنا إلى هذا الكيان "
-"الذي تقوم بالوصول إلى APIs أو تستخدمه نيابة عنه. إذا لم يكن لديك مثل هذه "
-"السلطة أو إذا لم تفهم الشروط أو لا ترغب في الالتزام بالشروط ، فيجب ألا "
-"تستخدم واجهات برمجة التطبيقات."
-
-#: lms/templates/api_admin/terms_of_service.html
-msgid ""
-"All names, logos and seals (\"Trademarks\") that appear in the APIs, API "
-"Content, or on or through the services made available on or through the "
-"APIs, if any, are the property of their respective owners. You may not "
-"remove, alter, or obscure any copyright, Trademark, or other proprietary "
-"rights notices incorporated in or accompanying the API Content. If any "
-"{platform_name} Participant (as hereinafter defined) or other third party "
-"revokes access to API Content owned or controlled by that {platform_name} "
-"Participant or third party, including without limitation any Trademarks, you"
-" must ensure that all API Content pertaining to that {platform_name} "
-"Participant or third party is deleted from Your Application and your "
-"networks, systems and servers as soon as reasonably possible. "
-"\"{platform_name_capitalized} Participants\" means MIT, Harvard, and the "
-"other entities providing information, API Content or services for the APIs, "
-"the course instructors and their staffs."
-msgstr ""
-"جميع الأسماء والشعارات والأختام (\"العلامات التجارية\") التي تظهر في واجهات "
-"برمجة التطبيقات أو محتوى واجهة برمجة التطبيقات أو في أو من خلال الخدمات "
-"المتاحة على واجهات برمجة التطبيقات أو من خلالها ، إن وجدت ، هي ملك لأصحابها."
-" لا يجوز لك إزالة أو تغيير أو إخفاء أي حقوق نشر أو علامة تجارية أو غيرها من "
-"إشعارات حقوق الملكية المضمنة في محتوى API أو المصاحبة له. إذا ألغى أي مشارك "
-"{platform_name} (كما هو موضح فيما يلي) أو جهة خارجية أخرى الوصول إلى محتوى "
-"واجهة برمجة التطبيقات الذي يملكه أو يتحكم فيه ذلك المشارك {platform_name} أو"
-" طرف ثالث ، بما في ذلك على سبيل المثال لا الحصر أي علامات تجارية ، فيجب عليك"
-" التأكد من أن جميع محتوى واجهة برمجة التطبيقات المتعلقة بذلك {platform_name}"
-" يتم حذف المشارك أو الجهة الخارجية من تطبيقك والشبكات والأنظمة والخوادم "
-"الخاصة بك في أقرب وقت ممكن. يُقصد بمصطلح \"{platform_name_capitalized} "
-"المشاركون\" معهد ماساتشوستس للتكنولوجيا وهارفارد والكيانات الأخرى التي توفر "
-"المعلومات أو محتوى واجهة برمجة التطبيقات أو الخدمات لواجهات برمجة التطبيقات "
-"ومعلمي الدورة وموظفيها."
-
 #: lms/templates/bulk_email/confirm_unsubscribe.html
 msgid ""
 "You will still receive course emails from other courses you are enrolled in."
@@ -2814,24 +2149,12 @@ msgid "The course information in the Course Administration tool."
 msgstr "معلومات المقرر في أداة إدارة المقرر."
 
 #: lms/templates/course_modes/choose.html
-msgid "Enroll In {course_name} | Choose Your Track"
-msgstr "سجل في {course_name} | اختر مسارك"
-
-#: lms/templates/course_modes/choose.html
 msgid ""
 "{b_start}Eligible for credit:{b_end} Receive academic credit after "
 "successfully completing the course"
 msgstr ""
 "{b_start}تأهِّلك للحصول على درجة:{b_end} احصل على درجة أكاديمية بعد استكمالك"
 " للمقرر بنجاح."
-
-#: lms/templates/course_modes/choose.html
-msgid ""
-"{b_start}Unlimited Course Access: {b_end}Learn at your own pace, and access "
-"materials anytime to brush up on what you've learned."
-msgstr ""
-"{b_start} دخول غير محدود إلى الدورة : {b_end} تعلم ذاتيًا، وتصفح المواد في "
-"أي وقت لصقل ما تعلمته."
 
 #: lms/templates/course_modes/choose.html
 msgid ""
@@ -2854,35 +2177,6 @@ msgstr ""
 #: lms/templates/course_modes/choose.html
 msgid "Audit This Course (No Certificate)"
 msgstr "سجِّل في هذا المقرر كمستمع (دون شهادة)"
-
-#: lms/templates/course_modes/choose.html
-msgid ""
-"Audit this course for free and have access to course materials and "
-"discussions forums. {b_start}This track does not include graded assignments,"
-" or unlimited course access.{b_end}"
-msgstr ""
-"قم بمراجعة هذه الدورة مجانًا وتمتع بإمكانية الوصول إلى مواد الدورة ومنتديات "
-"المناقشات. {b_start} لا يتضمن هذا المسار الواجبات المقدرة أو الوصول غير "
-"المحدود إلى الدورة. {b_end}"
-
-#: lms/templates/course_modes/choose.html
-msgid ""
-"Audit this course for free and have access to course materials and "
-"discussions forums. {b_start}This track does not include graded "
-"assignments.{b_end}"
-msgstr ""
-"قم بمراجعة هذه الدورة مجانًا وتمتع بإمكانية الوصول إلى مواد الدورة ومنتديات "
-"المناقشات. {b_start} لا يتضمن هذا المسار الواجبات المقدرة. {b_end}"
-
-#: lms/templates/course_modes/choose.html
-msgid ""
-"Audit this course for free and have access to course materials and "
-"discussions forums. {b_start}This track does not include unlimited course "
-"access.{b_end}"
-msgstr ""
-"قم بمراجعة هذه الدورة مجانًا وتمتع بإمكانية الوصول إلى مواد الدورة ومنتديات "
-"المناقشات. {b_start} لا يتضمن هذا المسار الوصول غير المحدود إلى الدورة. "
-"{b_end}"
 
 #: lms/templates/course_modes/choose.html
 msgid ""
@@ -2999,28 +2293,12 @@ msgid "Courses in the {}"
 msgstr "مقررات في {}"
 
 #: lms/templates/courseware/progress.html
-msgid "{course_number} Progress"
-msgstr "تقدّم العمل {course_number}"
-
-#: lms/templates/courseware/progress.html
 msgid "Requirements for Course Credit"
 msgstr "متطلبات النجاح في مواد المقرر"
 
 #: lms/templates/courseware/progress.html
 msgid "{student_name}, you are no longer eligible for credit in this course."
 msgstr "{student_name}، لم تعد مؤهلاً للحصول على مواد هذا المقرر."
-
-#: lms/templates/courseware/progress.html
-msgid ""
-"{student_name}, you have met the requirements for credit in this course. "
-"{a_start}Go to your dashboard{a_end} to purchase course credit."
-msgstr ""
-"{student_name}، لقد حققت متطلبات النجاح لهذه الدورة التعليمية. {a_start} "
-"توجه لزيارة لوحة معلوماتك{a_end} tلشراء مواد الدورة التعليمية."
-
-#: lms/templates/courseware/progress.html
-msgid "Information about course credit requirements"
-msgstr "معلومات حول متطلبات النجاح في مواد المقرر"
 
 #: lms/templates/courseware/syllabus.html
 msgid "{course.display_number_with_default} Course Info"
@@ -3090,36 +2368,12 @@ msgid "Course details"
 msgstr "تفاصيل المقرر"
 
 #: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "{course_number} {course_name} Home Page"
-msgstr "{course_number} {course_name} الصفحة الرئيسية"
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "{course_number} {course_name} Cover Image"
-msgstr "صورة الغلاف {course_number} {course_name} "
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
 msgid "You must select a session by {expiration_date} to access the course."
 msgstr "يجب عليك تحديد جلسة قبل تاريخ {expiration_date} للوصول إلى المقرر."
 
 #: lms/templates/dashboard/_dashboard_course_listing.html
 msgid "You must select a session to access the course."
 msgstr "يجب عليك تحديد جلسة للوصول إلى المقرر."
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "I'm taking {course_name} online with {facebook_brand}. Check it out!"
-msgstr "أنا آخذ {course_name} عبر الإنترنت مع {facebook_brand}. قم بتجربته!"
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "Share {course_name} on Facebook"
-msgstr "شارك {course_name} على فيسبوك"
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "I'm taking {course_name} online with {twitter_brand}. Check it out!"
-msgstr "أنا آخذ {course_name} عبر الإنترنت مع {twitter_brand}. قم بتجربته!"
-
-#: lms/templates/dashboard/_dashboard_course_listing.html
-msgid "Share {course_name} on Twitter"
-msgstr "شارك {course_name} على تويتر"
 
 #: lms/templates/dashboard/_dashboard_course_listing.html
 msgid "Course options for"
@@ -3161,14 +2415,6 @@ msgid ""
 msgstr ""
 "شكرًا لتسديدك الرسوم. وللحصول على وحدات دراسية للمقرر أطلبها من موقع "
 "{link_to_provider_site}. اختر {start_bold}Request Credit{end_bold} للبدء."
-
-#: lms/templates/dashboard/_dashboard_credit_info.html
-msgid ""
-"{provider_name} has received your course credit request. We will update you "
-"when credit processing is complete."
-msgstr ""
-"لقد استلم {provider_name} طلب الحصول على مادة دراسية الذي تقدّمت به. سنطلعك "
-"بالمستجدّات بمجرّد اكتمال معالجة طلبك."
 
 #. Translators: link_to_provider_site is a link to an external webpage. The
 #. text of the link will be the name of a credit provider, such as 'State
@@ -3249,13 +2495,13 @@ msgstr ""
 "تسليط الضوء على معلومات مهمّة لمراجعتها لاحقًا في المقرر أو في مقررات "
 "مستقبلية."
 
+#. Translators: please translate the text inside [[ ]]. This is meant as a
+#. template for course teams to use.
 #: lms/templates/emails/business_order_confirmation_email.txt
-msgid ""
-"To enroll in {course_names} we have provided a registration URL for you.  "
-"Please follow the instructions below to claim your access."
+msgid "Your redeem url is: [[Enter Redeem URL here from the attached CSV]]"
 msgstr ""
-"لقد زودناك برابط للتسجيل في {course_names}، يرجى اتّباع التعليمات الواردة "
-"أدناه لتتمكن من الدخول."
+"رابط الاسترداد الخاص بمقررك هو: [[أدخل رابط الاسترداد هنا من ملف CSV "
+"المرفَق]]"
 
 #: lms/templates/emails/business_order_confirmation_email.txt
 msgid ""
@@ -3269,6 +2515,12 @@ msgstr ""
 msgid ""
 "(5) Course materials will not be available until the course start date."
 msgstr "(5) لن تُتاح محتويات المقرر قبل أن يحين تاريخ بدء المقرر."
+
+#: lms/templates/emails/failed_verification_email.txt
+#: lms/templates/emails/photo_submission_confirmation.txt
+#: lms/templates/emails/reverification_processed.txt
+msgid "The {platform_name} team"
+msgstr "فريق المقرر {platform_name}"
 
 #: lms/templates/emails/reject_name_change.txt
 msgid ""
@@ -3398,14 +2650,6 @@ msgstr ""
 
 #: lms/templates/instructor/instructor_dashboard_2/certificates.html
 msgid ""
-"To regenerate certificates for your course, choose the learners who will "
-"receive regenerated certificates and click Regenerate Certificates."
-msgstr ""
-"لإعادة إصدار شهادات الدورة التدريبية، اختر المتعلّمين الذي تود أن يحصلوا على"
-" شهادات جديدة ثم اضغط على \"أعد إصدار الشهادات\"."
-
-#: lms/templates/instructor/instructor_dashboard_2/certificates.html
-msgid ""
 "Set exceptions to generate certificates for learners who did not qualify for"
 " a certificate but have been given an exception by the course team. After "
 "you add learners to the exception list, click Generate Exception "
@@ -3527,6 +2771,10 @@ msgid "View Course in Studio"
 msgstr "استعراض المقرر في استوديو"
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
+msgid "Batch Beta Tester Addition"
+msgstr "إضافة مختبري النسخة التجريبية للمقرر"
+
+#: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid ""
 "If this option is {em_start}checked{em_end}, users who have not enrolled in "
 "your course will be automatically enrolled."
@@ -3571,6 +2819,10 @@ msgstr ""
 "و’إنسايتس‘. يمكنك إعطاء أدوار أعضاء الفريق فقط للمستخدمين المسجلين."
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
+msgid "Add Staff"
+msgstr "إضافة أعضاء إلى طاقم المقرر"
+
+#: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid ""
 "Course team members with the Admin role help you manage your course. They "
 "can do all of the tasks that Staff can do, and can also add and remove the "
@@ -3606,18 +2858,6 @@ msgstr ""
 "المشاركات من جميع المجموعات. ويتم وضع مؤشر \"موظف\" على مشاركاتهم . كما "
 "يمكنهم إضافة أدوار الإشراف على المحادثات وإزالتها لإدارة عضوية فريق المقرر. "
 "يمكن إضافة المستخدمين المسجلين فقط كمسؤولين للمناقشة."
-
-#: lms/templates/instructor/instructor_dashboard_2/membership.html
-msgid "Course Data Researcher"
-msgstr "باحث بيانات الدورة"
-
-#: lms/templates/instructor/instructor_dashboard_2/membership.html
-msgid "Course Data Researchers can access the data download tab."
-msgstr "يمكن لباحثين بيانات الدورة الوصول إلى علامة تبويب تنزيل البيانات"
-
-#: lms/templates/instructor/instructor_dashboard_2/membership.html
-msgid "Add Course Data Researcher"
-msgstr "إضافة باحث بيانات الدورة"
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid ""
@@ -3674,14 +2914,6 @@ msgstr ""
 "يستطيع مدربو CCX إنشاء مقرر مخصص خاص بهم بناءًا على هذا المقرر والذي يمكنهم "
 "استخدامه لتزويد تعليمات مخصصة لطلابهم بناءًا على ما يرد في مواد هذا المقرر."
 
-#: lms/templates/instructor/instructor_dashboard_2/send_email.html
-msgid ""
-"To see the status for all email tasks submitted for this course, click this "
-"button:"
-msgstr ""
-"لرؤية حالة رسائل البريد التي أُرسلت لهذه الدورة التدريبية، قم بالضغط على هذا"
-" الزر:"
-
 #: lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
 msgid "Set Course Mode Price"
 msgstr "تحديد سعر وضعية المقرر"
@@ -3693,14 +2925,6 @@ msgstr "يرجى إدخال تفاصيل وضعية المقرر أدناه"
 #: lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
 msgid "Course Price"
 msgstr "سعر المقرر"
-
-#: lms/templates/instructor/instructor_dashboard_2/student_admin.html
-msgid ""
-"Note: This feature is available only to courses with a small number of "
-"enrolled learners."
-msgstr ""
-"ملاحظة:  هذه الميزة متاحة فقط في الدورات التي يكون عدد الطلاب المسجلّين فيها"
-" قليل."
 
 #: lms/templates/instructor/instructor_dashboard_2/student_admin.html
 msgid "Location of problem in course"
@@ -3802,6 +3026,22 @@ msgid ""
 "Here is a list of problems that need to be peer graded for this course."
 msgstr "فيما يلي قائمة بالمسائل التي يجب أن يصححها الزملاء في هذا المقرر "
 
+#: lms/templates/peer_grading/peer_grading_problem.html
+msgid ""
+"You will now be shown a series of instructor-scored essays, and will be "
+"asked to score them yourself."
+msgstr ""
+"سيتم إطلاعك الآن على سلسلة من المقالات التي تم تقييمها من قبل موجّه المقرر، "
+"وسيطلب منك تقييمهم بنفسك. "
+
+#: lms/templates/peer_grading/peer_grading_problem.html
+msgid ""
+"Once you can score the essays similarly to an instructor, you will be ready "
+"to grade your peers."
+msgstr ""
+"لدى تمكنك من تقييم المقالات بطريقة مشابهة لما يقوم به موجّه المقرر، ستكون "
+"جاهزاً عندها للقيام بالتقييم لزملائك. "
+
 #: lms/templates/static_templates/embargo.html
 msgid ""
 "Our system indicates that you are trying to access this {platform_name} "
@@ -3814,10 +3054,6 @@ msgstr ""
 "منطقة تخضع حاليًا لعقوبات اقتصادية وتجارية أمريكية. لسوء الحظ ، نظرًا لأن "
 "{platform_name} مطلوب للامتثال لضوابط التصدير ، لا يمكننا السماح لك بالوصول "
 "إلى هذا المقرر في الوقت الحالي."
-
-#: lms/templates/support/feature_based_enrollments.html
-msgid "Course Duration Limits"
-msgstr "حدود مدة الدورة"
 
 #: lms/templates/survey/survey.html
 msgid "Pre-Course Survey"
@@ -3844,14 +3080,6 @@ msgstr ""
 "والمستقبليين. فكلّما عرفنا أكثر عن احتياجاتك، تمكّنّا من زيادة تحسين تجربتك "
 "مع المقرر."
 
-#: lms/templates/survey/survey.html
-msgid ""
-"If you have any questions about this course or this form, you can contact "
-"{link_start}{mail_to_link}{link_end}."
-msgstr ""
-"إذا كان لديك أي أسئلة حول هذه الدورة أو الاستمارة، يمكنك الاتصال على "
-"{link_start}{mail_to_link}{link_end}."
-
 #: lms/templates/ux/reference/bootstrap/course-skeleton.html
 msgid "Search the course"
 msgstr "إبحث عن المقرر"
@@ -3866,29 +3094,13 @@ msgstr "يرجى إعادة التحقق للمقرر {course_name}"
 
 #: lms/templates/verify_student/missed_deadline.html
 msgid ""
-"The verification deadline for {course_name} was {{date}}. Verification is no"
-" longer available."
-msgstr ""
-"الموعد النهائي للتحقق للدورة التعليمية {course_name} كان في {{date}}. لم يعد"
-" التحقق متاحًا."
-
-#: lms/templates/verify_student/missed_deadline.html
-msgid ""
 "The deadline to upgrade to a verified certificate for this course has "
 "passed."
 msgstr "لقد انقضى موعد التحقّق النهائي المحدّد لهذا المقرر."
 
 #: lms/templates/verify_student/pay_and_verify.html
-msgid "Upgrade Your Enrollment For {course_name}."
-msgstr "تحديث تسجيلك في {course_name}."
-
-#: lms/templates/verify_student/pay_and_verify.html
 msgid "Verify For {course_name}"
 msgstr "إجراء عملية التحقّق الخاصة بالمقرر {course_name}"
-
-#: lms/templates/verify_student/pay_and_verify.html
-msgid "Enroll In {course_name}"
-msgstr "التسجيل في {course_name}"
 
 #: lms/templates/wiki/includes/breadcrumbs.html
 msgid "Course Wiki"
@@ -3909,17 +3121,9 @@ msgstr ""
 msgid "Study hard and pass the course"
 msgstr "ادرس بجد واجتاز المقرر"
 
-#: openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
-msgid "Upgrade ({course_price})"
-msgstr "ترقية ({course_price})"
-
 #: openedx/features/course_experience/templates/course_experience/course-updates-fragment.html
 msgid "This course does not have any updates."
 msgstr "لا يوجد تحديثات بالمقرر"
-
-#: openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
-msgid "{course_mode} certificate"
-msgstr "{course_mode} شهادة"
 
 #: openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
 msgid "Explore New Courses"
@@ -3967,6 +3171,14 @@ msgstr ""
 "{new_name}. إذا كنت بحاجة للمزيد من المساعدة، الرجاء مراسلة فريق الدعم الفني"
 " على البريد الإلكتروني {email}"
 
+#: cms/templates/500.html
+msgid ""
+"We've logged the error and our staff is currently working to resolve this "
+"error as soon as possible."
+msgstr ""
+"لقد سجّلنا الخطأ، يعمل طاقم المقرر حاليّاً على إيجاد حلّ له في أقرب وقت "
+"ممكن."
+
 #: cms/templates/certificates.html
 msgid "Course Certificates"
 msgstr "شهادات المقرر"
@@ -3990,16 +3202,6 @@ msgid ""
 msgstr ""
 "لعرض شهادة نموذجيّة، يُرجى اختيار وضع للمقرر وتحديد {em_start} معاينة "
 "الشهادة{em_end} "
-
-#: cms/templates/certificates.html
-msgid ""
-"To begin issuing course certificates, a course team member with either the "
-"Staff or Admin role selects {em_start}Activate{em_end}. Only course team "
-"members with these roles can edit or delete an activated certificate."
-msgstr ""
-"للبدء في إصدار شهادات لهذه الدورة التعليمية يقوم أحد أعضاء الفريق الذي يقوم "
-"بدور عضو طاقم أو مشرف  {em_start}Activate{em_end}. يمكن فقط لأعضاء فريق "
-"الدورة التعليمية الذي يشغلون هذه الأدوار تحرير أو حذف شهادة التي تم تفعيلها."
 
 #: cms/templates/certificates.html
 msgid ""
@@ -4154,18 +3356,6 @@ msgid ""
 "This course was created as a re-run. Some manual configuration is needed."
 msgstr ""
 "أُنشِئ هذا المقرر كتشغيل ثانٍ، ويتطلّب بالتالي ضبط بعض الإعدادات اليدوية."
-
-#: cms/templates/course_outline.html
-msgid ""
-"No course content is currently visible, and no learners are enrolled. Be "
-"sure to review and reset all dates, including the Course Start Date; set up "
-"the course team; review course updates and other assets for dated material; "
-"and seed the discussions and wiki."
-msgstr ""
-"لا يوجد محتوى للدورة التدريبية مرئيًا في الوقت الراهن، ولا يوجد متعلمون "
-"مسجلين. تأكد من مراجعة وإعادة تعيين كافة التواريخ، بما في ذلك تاريخ بدء "
-"الدورة التدريبية؛ إعداد فريق الدورة التدريبية؛ مراجعة تحديثات الدورة "
-"التدريبية وغيرها من الأصول للمواد المؤرخة؛ وتنظيم المناقشات والويكي."
 
 #: cms/templates/course_outline.html
 msgid "This course uses features that are no longer supported."
@@ -4477,13 +3667,21 @@ msgstr "إبقاء مقررك منظّمًا "
 
 #: cms/templates/howitworks.html
 msgid ""
-"The backbone of your course is how it is organized. {studio_name} offers an "
-"{strong_start}Outline{strong_end} editor, providing a simple hierarchy and "
-"easy drag and drop to help you and your students stay organized."
+"Draft your outline and build content anywhere. Simple drag and drop tools "
+"let you reorganize quickly."
 msgstr ""
-"العمود الفقري لدورتك التدريبية يتمثل في كيفية تنظيمها. {studio_name} يقدم "
-"محرر {strong_start}Outline{strong_end}، مما يوفر تسلسلاً هرميًا بسيطًا وسهل "
-"السحب والإسقاط لمساعدتك وطلابك على البقاء في حالة منظمة."
+"يمكنك صياغة المخطّط الكلّي لمقررك وبناء محتواه أينما كنت. فإنّ أدوات السحب "
+"والإسقاط البسيطة المتاحة تسمح لك بإعادة تنظيم المقرر بسرعة. "
+
+#: cms/templates/howitworks.html
+msgid ""
+"{studio_name} lets you weave your content together in a way that reinforces "
+"learning. Insert videos, discussions, and a wide variety of exercises with "
+"just a few clicks."
+msgstr ""
+"يسمح لك استوديو {studio_name} بجمع محتويات مقررك بطريقة تعزّز دراستك، إذ "
+"يمكنك تضمين الفيديوهات، والنقاشات، ومجموعة كبيرة من مختلف التمارين بمجرّد "
+"القيام بنقرات قليلة. "
 
 #: cms/templates/howitworks.html
 msgid ""
@@ -4499,15 +3697,6 @@ msgstr ""
 
 #: cms/templates/howitworks.html
 msgid ""
-"When you've finished a {strong_start}section{strong_end}, pick when you want"
-" it to go live and {studio_name} takes care of the rest. Build your course "
-"incrementally."
-msgstr ""
-"عند الانتهاء من {strong_start}section{strong_end}، اختر عندما تود إجراء بث "
-"حي و{studio_name} يعتني بالبقية. ابن دورتك التدريبية تدريجيًا."
-
-#: cms/templates/howitworks.html
-msgid ""
 "Co-authors have full access to all the same authoring tools. Make your "
 "course better through a team effort."
 msgstr ""
@@ -4515,24 +3704,23 @@ msgstr ""
 " إذًا أن تحسّن جودة مقررك من خلال جهد جماعي. "
 
 #: cms/templates/howitworks.html
-msgid "Sign Up & Start Making Your {platform_name} Course"
-msgstr "الاشتراك وبدء إنشاء دورتك التدريبية {platform_name}"
-
-#: cms/templates/howitworks.html
 msgid "Outlining Your Course"
 msgstr "وضع المخطّط الكلّي لمقررك"
-
-#: cms/templates/howitworks.html
-msgid ""
-"Simple two-level outline to organize your course. Drag and drop, and see "
-"your course at a glance."
-msgstr ""
-"مخطط بسيط من مستويين لتنظيم دورتك التدريبية. اسحب وأسقط، وشاهد دورتك "
-"التدريبية في لمحة."
 
 #: cms/templates/import.html
 msgid "Course Import"
 msgstr "استيراد المقرر"
+
+#: cms/templates/import.html
+msgid ""
+"The import process has five stages. During the first two stages, you must "
+"stay on this page. You can leave this page after the Unpacking stage has "
+"completed. We recommend, however, that you don't make important changes to "
+"your library until the import operation has completed."
+msgstr ""
+"تمرّ عملية الاستيراد بخمس مراحل. وعليك أن تبقى في هذه الصفحة في أوّل "
+"مرحلتين. ثمّ يمكنك مغادرة هذه الصفحة بعد أن تُستكمل مرحلة التفريغ. ولكنّنا "
+"نوصيك بعدم إجراء تغييرات أساسية في مقررك قبل أن تُستكمل عملية الاستيراد."
 
 #: cms/templates/import.html
 msgid ""
@@ -4813,6 +4001,14 @@ msgstr ""
 
 #: cms/templates/index.html
 msgid ""
+"The library creator must give you access to the library. Contact the library"
+" creator or administrator for the library you are helping to author."
+msgstr ""
+"يجب أن يمنحك منشئ المقرر صلاحية دخول المكتبة. لذا يُرجى التواصل معه أو مع "
+"مشرِف المكتبة التي تساعد على تأليفها. "
+
+#: cms/templates/index.html
+msgid ""
 "Libraries hold a pool of components that can be re-used across multiple "
 "courses. Create your first library with the click of a button!"
 msgstr ""
@@ -4944,6 +4140,11 @@ msgstr ""
 "المستخدمين الجدد للمكتبة أن يكون لديهم حساب نشط لدى {studio_name}. "
 
 #: cms/templates/manage_users_lib.html
+msgid "There are three access roles for libraries: User, Staff, and Admin."
+msgstr ""
+"هناك ثلاثة أدوار تتيح الدخول إلى المكتبات: المستخدم وطاقم المقرر والمشرِف."
+
+#: cms/templates/manage_users_lib.html
 msgid ""
 "Library Users can view library content and can reference or use library "
 "components in their courses, but they cannot edit the contents of a library."
@@ -5024,6 +4225,10 @@ msgstr ""
 "يمكنك ضبط تواريخ نشر محتوى المقرر وتواريخ تسليم الواجبات."
 
 #: cms/templates/settings.html
+msgid "Self-Paced"
+msgstr "مقرر دائم"
+
+#: cms/templates/settings.html
 msgid ""
 "Self-paced courses offer suggested due dates for assignments or exams based "
 "on the learner’s enrollment date and the expected course duration. These "
@@ -5087,40 +4292,6 @@ msgid "Introducing Your Course"
 msgstr "التعريف عن مقررك"
 
 #: cms/templates/settings.html
-msgid "Course Title"
-msgstr "عنوان الدورة"
-
-#: cms/templates/settings.html
-msgid "Displayed as title on the course details page. Limit to 50 characters."
-msgstr "يظهر كعنوان على صفحة تفاصيل الدورة التدريبية. محدد على 50 رمزًا."
-
-#: cms/templates/settings.html
-msgid "Course Subtitle"
-msgstr "عنوان الدورة الفرعي"
-
-#: cms/templates/settings.html
-msgid ""
-"Displayed as subtitle on the course details page. Limit to 150 characters."
-msgstr ""
-"يظهر كعنوان فرعي على صفحة تفاصيل الدورة التدريبية. محدد على 150 رمزًا."
-
-#: cms/templates/settings.html
-msgid "Course Duration"
-msgstr "مدة الدورة"
-
-#: cms/templates/settings.html
-msgid "Displayed on the course details page. Limit to 50 characters."
-msgstr "يظهر على صفحة تفاصيل الدورة التدريبية. محدد على 50 رمزًا."
-
-#: cms/templates/settings.html
-msgid "Course Description"
-msgstr "وصف الدورة"
-
-#: cms/templates/settings.html
-msgid "Displayed on the course details page. Limit to 1000 characters."
-msgstr "يظهر على صفحة تفاصيل الدورة. مُحدد ل1000 حرف."
-
-#: cms/templates/settings.html
 msgid "Course Short Description"
 msgstr "الوصف المختصر للمقرر"
 
@@ -5137,14 +4308,6 @@ msgid "Course Overview"
 msgstr "نظرة عامة عن المقرر"
 
 #: cms/templates/settings.html
-msgid ""
-"Introductions, prerequisites, FAQs that are used on {a_link_start}your "
-"course summary page{a_link_end} (formatted in HTML)"
-msgstr ""
-"المقدمات والمتطلبات الأساسية المسبقة والأسئلة الشائعة التي تستخدم في "
-"{a_link_start} صفحة ملخص دورتك التدريبية {a_link_end} (formatted in HTML)  "
-
-#: cms/templates/settings.html
 msgid "Course About Sidebar HTML"
 msgstr "الشريط الجانبي عن المقرر HTML"
 
@@ -5155,10 +4318,6 @@ msgid ""
 msgstr ""
 "محتوى الشريط الجانبي المخصص لـ {a_link_start} صفحة ملخص المقرر {a_link_end} "
 "(بتنسيق HTML)"
-
-#: cms/templates/settings.html
-msgid "Course Card Image"
-msgstr "صورة بطاقة الدورة التدريبية"
 
 #: cms/templates/settings.html
 msgid ""
@@ -5183,43 +4342,8 @@ msgstr ""
 "أو PNG فقط)"
 
 #: cms/templates/settings.html
-msgid "Upload Course Card Image"
-msgstr "تحميل صورة بطاقة الدورة التدريبية"
-
-#: cms/templates/settings.html
-msgid ""
-"Your course currently does not have an image. Please upload one (JPEG or PNG"
-" format, and minimum suggested dimensions are 1440px wide by 400px tall)"
-msgstr ""
-"لا تحتوي دورتك التدريبية على صورة في الوقت الحالي. الرجاء رفع صورة (تنسيق "
-"JPEG أو PNG، والحد الأدنى المقترح للأبعاد هو 1440 بيكسل بالنسبة للعرض في 400"
-" بيكسل بالنسبة للطول)"
-
-#: cms/templates/settings.html
-msgid "Upload Course Banner Image"
-msgstr "رفع صورة شعار دورتك التدريبية"
-
-#: cms/templates/settings.html
-msgid ""
-"Your course currently does not have a video thumbnail image. Please upload "
-"one (JPEG or PNG format, and minimum suggested dimensions are 375px wide by "
-"200px tall)"
-msgstr ""
-"لا تحتوي دورتك التدريبية على ‏‫صورة فيديو مصغرة في الوقت الحالي. الرجاء رفع "
-"صورة (تنسيق JPEG أو PNG، والحد الأدنى المقترح للأبعاد هو 375 بيكسل بالنسبة "
-"للعرض في 200 بيكسل بالنسبة للطول)"
-
-#: cms/templates/settings.html
 msgid "Course Introduction Video"
 msgstr "فيديو مقدّمة المقرر"
-
-#: cms/templates/settings.html
-msgid "Add the learning outcomes for this course"
-msgstr "إضافة نتائج تعلُّم لهذه الدورة التدريبية"
-
-#: cms/templates/settings.html
-msgid "Add details about the instructors for this course"
-msgstr "إضافة تفاصيل بشأن معلمي هذه الدورة التدريبية"
 
 #: cms/templates/settings.html
 msgid "Expectations of the students taking this course"
@@ -5286,6 +4410,10 @@ msgstr ""
 "سيلتحقون بها."
 
 #: cms/templates/settings_advanced.html
+msgid "Your policy changes have been saved."
+msgstr "حُفّظت التغييرات التي أدخلتها على سياسة مقررك."
+
+#: cms/templates/settings_advanced.html
 msgid ""
 "Advanced settings control specific course functionality. On this page, you "
 "can edit manual policies, which are JSON-based key and value pairs that "
@@ -5296,22 +4424,20 @@ msgstr ""
 "بإعدادت المقرر المحدّدة. "
 
 #: cms/templates/settings_graders.html
+msgid "Credit Eligibility"
+msgstr "الأهلية للمقرر"
+
+#: cms/templates/settings_graders.html
 msgid "Settings for course credit eligibility"
 msgstr "إعدادات الأهلية لمواد المقرر"
 
 #: cms/templates/settings_graders.html
-msgid "Must be greater than or equal to the course passing grade"
-msgstr "يجب أن تزيد عن درجة النجاح في المقرر أو تساويها"
+msgid "Minimum Credit-Eligible Grade:"
+msgstr "الدرجة الدنيا للأهلية للمقرر:"
 
 #: cms/templates/settings_graders.html
-msgid ""
-"You can use the slider under Overall Grade Range to specify whether your "
-"course is pass/fail or graded by letter, and to establish the thresholds for"
-" each grade."
-msgstr ""
-"يمكنك استخدام شريط التمرير المبيّن تحت ’نطاق الدرجات النهائية‘ لتحدّد نوع "
-"الدرجات التي تفضّل أن تتلقّاها؛ أي أن تُحتسَب إمّا بالأرقام أو بالأحرف، "
-"ولتحدّد أيضًَا الحدّ الأدنى لكلّ درجة."
+msgid "Must be greater than or equal to the course passing grade"
+msgstr "يجب أن تزيد عن درجة النجاح في المقرر أو تساويها"
 
 #: cms/templates/settings_graders.html
 msgid ""
@@ -5375,23 +4501,11 @@ msgstr ""
 msgid "Your course creator status for {studio_name}"
 msgstr "حالة منشئ مقررك في {studio_name}"
 
-#: cms/templates/maintenance/_force_publish_course.html
-msgid "Required data to force publish course."
-msgstr "البيانات المطلوبة لتنفيذ النشر للدورة التدريبية."
-
-#: cms/templates/maintenance/_force_publish_course.html
-msgid "course-v1:edX+DemoX+Demo_Course"
-msgstr "course-v1:edX+DemoX+Demo_Course"
-
 #: cms/templates/registration/activation_complete.html
 msgid "Visit your {link_start}dashboard{link_end} to see your courses."
 msgstr ""
 "تفضّل بزيارة {link_start}لوحة المعلومات{link_end} الخاصة بحسابك لرؤية "
 "مقرراتك."
-
-#: cms/templates/widgets/deprecated-course-key-warning.html
-msgid "This course uses a legacy storage format."
-msgstr "تستخدم هذه الدورة تنسيق تخزين قديم."
 
 #: cms/templates/widgets/header.html
 msgid "Current Course:"

--- a/translation-overrides/edx-platform/conf/locale/ar/LC_MESSAGES/djangojs.po
+++ b/translation-overrides/edx-platform/conf/locale/ar/LC_MESSAGES/djangojs.po
@@ -31,10 +31,6 @@ msgid "Not specific to a course"
 msgstr "غير مخصص لمقرر معين"
 
 #: lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
-msgid "Course Content"
-msgstr "محتوى المقرر"
-
-#: lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
 msgid "Course Discussion Forum"
 msgstr "منتدى مناقشة المقرر"
 
@@ -94,49 +90,12 @@ msgid ""
 "exception list"
 msgstr "الطالب غير مسجل في المقرر ولم تتم إضافته إلى لائحة الاستثناءات"
 
-#: lms/static/js/certificates/views/certificate_bulk_allowlist.js
-msgid ""
-" learners have an active certificate invalidation in this course and have "
-"not been added to the exception list"
-msgstr ""
-"الطلّاب لديهم إبطال شهادة نشطة في هذه الدورة التدريبية ولم تتم إضافتهم إلى "
-"قائمة الاستثناءات"
-
-#: lms/static/js/certificates/views/certificate_bulk_allowlist.js
-msgid ""
-" learner has an active certificate invalidation in this course and has not "
-"been added to the exception list"
-msgstr ""
-"الطالب لدبه شهادة نشطة في هذه الدورة التدريبية ولم تتم إضافته إلى قائمة "
-"الاستثناءات"
-
 #: lms/static/js/dashboard/legacy.js
 msgid ""
 "Are you sure you want to unenroll from the purchased course {courseName} "
 "({courseNumber})?"
 msgstr ""
 "هل أنت متأكّد من رغبتك في إلغاء تسجيلك في المقرر الذي انضممت إليه  "
-"{courseName} ({courseNumber})؟"
-
-#: lms/static/js/dashboard/legacy.js
-msgid "Are you sure you want to unenroll from {courseName} ({courseNumber})?"
-msgstr ""
-"هل أنت متأكّد من رغبتك في إلغاء تسجيلك في {courseName} ({courseNumber})؟"
-
-#: lms/static/js/dashboard/legacy.js
-msgid ""
-"Are you sure you want to unenroll from the verified {certNameLong}  track of"
-" {courseName}  ({courseNumber})?"
-msgstr ""
-"هل أنت متأكّد من رغبتك بإلغاء تسجيلك من المسار الموثق {certNameLong} ل "
-"{courseName} ({courseNumber})؟"
-
-#: lms/static/js/dashboard/legacy.js
-msgid ""
-"Are you sure you want to unenroll from the verified {certNameLong} track of "
-"{courseName} ({courseNumber})?"
-msgstr ""
-"هل أنت متأكّد من رغبتك بإلغاء تسجيلك من المسار الموثق {certNameLong} ل "
 "{courseName} ({courseNumber})؟"
 
 #: lms/static/js/dashboard/legacy.js
@@ -208,6 +167,38 @@ msgstr "هل تريد البدء بإعداد الشهادات لجميع الط
 msgid "Start regenerating certificates for students in this course?"
 msgstr "هل تودّ معاودة البدء بإعداد الشهادات لطلّاب هذا المقرر؟"
 
+#: lms/static/js/instructor_dashboard/membership.js
+msgid "Error: You cannot remove yourself from the Instructor group!"
+msgstr "خطأ: لا يمكنك حذف نفسك من مجموعة أستاذ المقرر!"
+
+#. Translators: A list of users appears after this sentence;
+#: lms/static/js/instructor_dashboard/membership.js
+msgid ""
+"Successfully sent enrollment emails to the following users. They will be "
+"allowed to enroll once they register:"
+msgstr ""
+"جرى بنجاح مراسلة المستخدمين التالين عبر البريد الإلكتروني حول معلومات "
+"التسجيل، وسيُسمح لهم بالالتحاق بالمقرر حالما يسجّلون أنفسهم: "
+
+#. Translators: A list of users appears after this sentence;
+#: lms/static/js/instructor_dashboard/membership.js
+msgid "These users will be allowed to enroll once they register:"
+msgstr "سيُسمح للمستخدمين التالين بالالتحاق بالمقرر حالما يسجّلون أنفسهم: "
+
+#. Translators: A list of users appears after this sentence;
+#: lms/static/js/instructor_dashboard/membership.js
+msgid ""
+"Successfully sent enrollment emails to the following users. They will be "
+"enrolled once they register:"
+msgstr ""
+"جرى بنجاح مراسلة المستخدمين التالين عبر البريد الإلكتروني حول معلومات "
+"التسجيل، وسيجري إلحاقهم بالمقرر حالما يسجّلون أنفسهم: "
+
+#. Translators: A list of users appears after this sentence;
+#: lms/static/js/instructor_dashboard/membership.js
+msgid "These users will be enrolled once they register:"
+msgstr "سيجري إلحاق المستخدمين التالين بالمقرر حالما يسجّلون أنفسهم: "
+
 #. Translators: A list of users appears after this sentence;
 #: lms/static/js/instructor_dashboard/membership.js
 msgid ""
@@ -229,23 +220,6 @@ msgstr ""
 "لم يكن هؤلاء المستخدمون منتسبين إلى المقرر وبالتالي تعذّر إلغاء تسجيلهم:"
 
 #: lms/static/js/instructor_dashboard/send_email.js
-msgid "Everyone who has staff privileges in this course"
-msgstr "كل فرد لديه مزايا الموظفين في هذه الدورة التدريبية"
-
-#: lms/static/js/instructor_dashboard/send_email.js
-msgid "All learners who are enrolled in this course"
-msgstr "كل المتعلمين المنضمين إلى هذه الدورة التدريبية ."
-
-#: lms/static/js/instructor_dashboard/send_email.js
-msgid ""
-"Your email message was successfully queued for sending. In courses with a "
-"large number of learners, email messages to learners might take up to an "
-"hour to be sent."
-msgstr ""
-"تم جدولة إرسال رسالتك بنجاح. قد يستغرق إرسال الرسالة لجميع متعلمي الدورة "
-"التدريبية ساعة كاملة، ويعتمد ذلك على عدد المتعلمين في الدورة التدريبية."
-
-#: lms/static/js/instructor_dashboard/send_email.js
 msgid "There is no email history for this course."
 msgstr "لا يوجد سجلّ لرسائل البريد الإلكتروني الخاصة بهذا المقرر."
 
@@ -261,21 +235,9 @@ msgstr ""
 "نأسف لحدوث خطأ أثناء محاولة الحصول على سجل محتوى رسائل البريد الإلكتروني "
 "لهذا المقرر."
 
-#: lms/static/js/learner_dashboard/EnterpriseLearnerPortalModal.jsx
-msgid ""
-"To access the courses available to you through {enterpriseName}, visit the "
-"{enterpriseName} dashboard."
-msgstr ""
-"للوصول إلى الدورات التدريبية المتاحة لك من خلال {enterpriseName} ، قم بزيارة"
-" لوحة معلومات {enterpriseName}."
-
 #: lms/static/js/learner_dashboard/views/course_entitlement_view.js
 msgid "You must select a session to access the course."
 msgstr "يجب عليك تحديد جلسة للوصول إلى المقرر."
-
-#: lms/static/js/learner_dashboard/views/course_entitlement_view.js
-msgid "Any course progress or grades from your current session will be lost."
-msgstr "سوف تفقد أي تقدم أو علامات محتسبة من هذه الجلسة."
 
 #: lms/static/js/learner_dashboard/views/entitlement_unenrollment_view.js
 msgid ""
@@ -284,23 +246,6 @@ msgid ""
 msgstr ""
 "هل أنت متأكد من رغبتك في إلغاء التسجيل من المقرر {courseName} "
 "({courseNumber})؟ سوف يتم إعادة المبلغ المدفوع."
-
-#: lms/static/js/student_account/components/StudentAccountDeletion.jsx
-msgid ""
-"Once your account is deleted, you cannot use it to take courses on the "
-"{platformName} app, {siteName}, or any other site hosted by {platformName}."
-msgstr ""
-"عند حذف حسابك لن تتمكن من استخدامه لأخذ دورات على تطبيق {platformName} أو "
-"{siteName} أو أي موقع آخر يستضيفه {platformName}."
-
-#: lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
-msgid ""
-"If you proceed, you will be unable to use this account to take courses on "
-"the {platformName} app, {siteName}, or any other site hosted by "
-"{platformName}."
-msgstr ""
-"عند المتابعة لن تتمكن من استخدام هذا الحساب لأخذ دورات على تطبيق "
-"{platformName} أو {siteName} أو أي موقع آخر يستضيفه {platformName}."
 
 #: lms/static/js/student_account/views/FinishAuthView.js
 msgid "Enrolling you in the selected course"
@@ -318,16 +263,6 @@ msgstr "جاري تحميل مقرراتك"
 msgid ""
 "You receive messages from {platform_name} and course teams at this address."
 msgstr "تتلقى رسائل من {platform_name} وفرق المقررات على هذا العنوان."
-
-#: lms/static/js/student_account/views/account_settings_factory.js
-msgid ""
-"Select the time zone for displaying course dates. If you do not specify a "
-"time zone, course dates, including assignment deadlines, will be displayed "
-"in your browser's local time zone."
-msgstr ""
-"حدد المنطقة الزمنية لعرض مواعيد الدورة. إذا لم تقم بتحديد منطقة زمنية، سيتم "
-"عرض مواعيد الدورة، بما في ذلك مواعيد تقديم الواجبات، وفقاً لمنطقة التوقيت "
-"المحلي في المتصفح."
 
 #: lms/static/lms/js/preview/preview_factory.js
 msgid "Course is not yet visible to students."
@@ -367,6 +302,12 @@ msgid ""
 "“{container}”?"
 msgstr "هل أنت متأكّد من رغبتك في حذف {email} من فريق المقرر لـ \"{container}\"؟"
 
+#: cms/static/js/factories/manage_users.js
+#: cms/static/js/factories/manage_users_lib.js
+#: common/static/common/templates/discussion/templates.underscore
+msgid "Staff"
+msgstr "طاقم المقرر"
+
 #: cms/static/js/features/import/factories/import.js
 msgid "There was an error while importing the new course to our database."
 msgstr "نأسف لحدوث خطأ أثناء استيراد المقرر الجديد إلى قاعدة بياناتنا."
@@ -386,6 +327,11 @@ msgstr "يجب أن يأتي تاريخ انتهاء المقرر بعد تار�
 #: cms/static/js/models/settings/course_details.js
 msgid "The course start date must be later than the enrollment start date."
 msgstr "يجب أن يأتي تاريخ بدء المقرر بعد تاريخ التسجيل فيه."
+
+#: cms/static/js/models/settings/course_details.js
+msgid "The enrollment start date cannot be after the enrollment end date."
+msgstr ""
+"لا يمكن لتاريخ بدء التسجيل في المقرر أن يأتي بعد تاريخ انتهاء التسجيل فيه. "
 
 #: cms/static/js/models/settings/course_details.js
 msgid "The enrollment end date cannot be after the course end date."
@@ -427,14 +373,6 @@ msgstr "فهرس المقرر"
 msgid "There were errors reindexing course."
 msgstr "نأسف لحدوث أخطاء في إعادة فهرسة محتويات المقرر."
 
-#: cms/static/js/views/previous_video_upload.js
-msgid ""
-"Removing a video from this list does not affect course content. Any content "
-"that uses a previously uploaded video ID continues to display in the course."
-msgstr ""
-"لا يؤثر حذف فيديو من هذه القائمة على محتوى المقرر. ويستمر عرض أي محتوى "
-"يستخدم معرف فيديو محملًا سابقًا في هذا المقرر."
-
 #: cms/static/js/views/settings/main.js
 msgid "Course Credit Requirements"
 msgstr "متطلّبات مواد المقرر"
@@ -459,11 +397,6 @@ msgstr ""
 "لا يمكن التراجع لاحقًا عن عملية حذف الكتاب> وحالما تحذفه، سيجري أيضًا حذف "
 "أيٍّ من مراجعه الواردة في صفحاتك لمنهاج المقرر. "
 
-#: common/static/common/templates/discussion/templates.underscore
-#, python-format
-msgid "Related to: %(courseware_title_linked)s"
-msgstr "متعلِّقٌ بِـ: %(courseware_title_linked)s"
-
 #: lms/djangoapps/support/static/support/templates/certificates.underscore
 msgid "course id"
 msgstr "رقم تعريف المقرر "
@@ -484,9 +417,10 @@ msgstr "تاريخ ابتداء المقرر"
 msgid "Course End"
 msgstr "تاريخ انتهاء المقرر"
 
-#: lms/templates/api_admin/catalog-results.underscore
-msgid "This catalog's courses:"
-msgstr "الدورات التدريبية الخاصة بهذا الكتالوج:"
+#: lms/static/js/fixtures/donation.underscore
+#: lms/templates/dashboard/donation.underscore
+msgid "Donate"
+msgstr "المركز"
 
 #: lms/templates/financial-assistance/financial_assessment_submitted.underscore
 msgid ""
@@ -495,10 +429,6 @@ msgid ""
 msgstr ""
 "نشكرك لتقديمك طلب دعم مالي للمقرر {course_name}! يمكنك أن تتوقع استلام الردّ"
 " خلال 2-4 أيام عمل."
-
-#: lms/templates/instructor/instructor_dashboard_2/cohort-form.underscore
-msgid "Only the parent course staff of a CCX can create content groups."
-msgstr "يمكن فقط لطاقم الدورة الأم لـ CCX إنشاء مجموعات المحتوى."
 
 #: lms/templates/instructor/instructor_dashboard_2/cohorts.underscore
 msgid ""
@@ -537,12 +467,6 @@ msgstr "للدخول إلى المقرر ، حدد جلسة."
 #: lms/templates/learner_dashboard/course_entitlement.underscore
 msgid "Session Selection Dropdown for {courseName}"
 msgstr "القائمة المنسدلة لاختيار الجلسة للمقرر {courseName}"
-
-#: lms/templates/learner_dashboard/explore_new_programs.underscore
-msgid ""
-"Browse recently launched courses and see what\\'s new in your favorite "
-"subjects"
-msgstr "تصفح الفصول حديثة الإنشاء وشاهد الجديد في مواضيعك المفضلة."
 
 #: lms/templates/learner_dashboard/program_card.underscore
 #: lms/templates/verify_student/enrollment_confirmation_step.underscore
@@ -608,10 +532,6 @@ msgstr ""
 " "
 
 #: lms/templates/verify_student/intro_step.underscore
-msgid "Thanks for returning to verify your ID in: {courseName}"
-msgstr "شكراً لعودتك لتأكيد بطاقتك الشخصية في : {courseName}"
-
-#: lms/templates/verify_student/intro_step.underscore
 msgid ""
 "You need to activate your account before you can enroll in courses. Check "
 "your inbox for an activation email. After you complete activation you can "
@@ -620,15 +540,6 @@ msgstr ""
 "تحتاج إلى تفعيل حسابك قبل أن تتمكّن من التسجيل في المقررات. لذا يُرجى تفقّد "
 "صندوق بريدك الإلكتروني حيث ستردك رسالة تفعيل. وبعد أن تنتهي من التفعيل، "
 "يمكنك العودة وإعادة فتح هذه الصفحة. "
-
-#: lms/templates/verify_student/make_payment_step.underscore
-#: lms/templates/verify_student/make_payment_step_ab_testing.underscore
-msgid "You are enrolling in: {courseName}"
-msgstr "أنت مسجل في : {courseName}"
-
-#: lms/templates/verify_student/make_payment_step.underscore
-msgid "You are upgrading your enrollment for: {courseName}"
-msgstr "أنت تطور اشتراكك في: {courseName}"
 
 #: lms/templates/verify_student/make_payment_step.underscore
 msgid ""
@@ -643,29 +554,6 @@ msgstr ""
 "إنّ جميع مقررات التعليم المهني تستلزم رسماً وتتطلّب الدفع لاستكمال عملية "
 "التسجيل."
 
-#: lms/templates/verify_student/make_payment_step_ab_testing.underscore
-msgid "Upgrade to a Verified Certificate for {courseName}"
-msgstr "طور إلى شهادة من معتمدة إلى {courseName}"
-
-#: lms/templates/verify_student/make_payment_step_ab_testing.underscore
-msgid "Professional Certificate for {courseName}"
-msgstr "شهادة احترافية لـ {courseName}"
-
-#: lms/templates/verify_student/make_payment_step_ab_testing.underscore
-msgid "Verified Certificate for {courseName}"
-msgstr "شهادة معتمدة لـ {courseName}"
-
-#: lms/templates/verify_student/reverify_success_step.underscore
-msgid ""
-"We have received your information and are verifying your identity. You will "
-"see a message on your dashboard when the verification process is complete "
-"(usually within 5-7 days). In the meantime, you can still access all "
-"available course content."
-msgstr ""
-"لقد استلمنا معلوماتك ونتولّى حاليًا التحقّق من هويتك. ستصلك رسالة على لوحة "
-"معلوماتك عند اكتمال عملية التحقّق (عادةً خلال ٥-٧ أيام). ويمكنك في الوقت "
-"الراهن استخدام كافة محتويات الدورة المُتاحة."
-
 #: openedx/features/course_bookmarks/static/course_bookmarks/templates/bookmarks-list.underscore
 msgid "You have not bookmarked any courseware pages yet"
 msgstr "لم تؤشّر بعد على أي صفحة من صفحات المقرر"
@@ -679,9 +567,15 @@ msgstr ""
 "إلى صفحات المقرر. للتأشير على صفحة ما،  انقر على \"التأشير على هذه الصفحة\" "
 "تحت عنوان الصفحة."
 
-#: openedx/features/learner_profile/static/learner_profile/templates/badge_placeholder.underscore
-msgid "Find a course"
-msgstr "ابحث عن مادة"
+#: cms/templates/js/access-editor.underscore
+msgid ""
+"Select a prerequisite subsection and enter a minimum score percentage and "
+"minimum completion percentage to limit access to this subsection. Allowed "
+"values are 0-100"
+msgstr ""
+"حدد قسماً فرعياً أساسياً وأدخل النسبة المئوية الأدنى للعلامة والحد الأدنى "
+"لنسبة الإنجاز من المقرر لتحديد الوصول إلى هذا القسم الفرعي، القيم المسموح "
+"بها هي 0-100"
 
 #: cms/templates/js/asset-library.underscore
 msgid "List of uploaded files and assets in this course"
@@ -733,17 +627,13 @@ msgstr ""
 "بعد مرور تاريخ انتهاء المقرر/ات، لن يتمكن المتعلمين من الدخول إلى المحتوى "
 "الفرعي. ولكن سيبقى القسم الفرعي موجودًا عند احتساب الدرجة."
 
-#: cms/templates/js/content-visibility-editor.underscore
-msgid ""
-"Learners do not see the subsection in the course outline. The subsection is "
-"not included in grade calculations."
-msgstr ""
-"لا يرى المتعلمون القسم الفرعي في مخطط الدورة التدريبية. لم يتم تضمين القسم "
-"الفرعي في حسابات المستوى."
-
 #: cms/templates/js/course-highlights-enable.underscore
 msgid "Course Highlight Emails"
 msgstr "رسائل بريد تلميحات المقرر"
+
+#: cms/templates/js/course-outline.underscore
+msgid "Contains staff only content"
+msgstr "تحوي محتوىً خاص بطاقم المقرر فقط."
 
 #: cms/templates/js/course-outline.underscore
 msgid "Subsection is hidden after course end date"
@@ -772,6 +662,10 @@ msgid ""
 "assignment type."
 msgstr ""
 "عدد الأقسام الفرعية لهذا المقرر، التي تتضمن مسائل لمهمّة من هذا النوع."
+
+#: cms/templates/js/course_grade_policy.underscore
+msgid "Number of Droppable"
+msgstr "عدد المقررات التي يمكن الانسحاب منها"
 
 #: cms/templates/js/course_info_handouts.underscore
 msgid "Course Handouts"
@@ -803,6 +697,30 @@ msgstr ""
 "في {linkStart}مخطط المقرر{linkEnd} ، استخدم هذه المجموعة للتحكم في الوصول "
 "إلى عنصر."
 
+#: cms/templates/js/publish-xblock.underscore
+msgid "Visible to Staff Only"
+msgstr "مرئيّة لطاقم المقرر فقط"
+
+#: cms/templates/js/publish-xblock.underscore
+msgid "Staff Only"
+msgstr "طاقم المقرر فقط"
+
+#: cms/templates/js/timed-examination-preference-editor.underscore
+msgid "Timed"
+msgstr "موقوت"
+
+#: cms/templates/js/timed-examination-preference-editor.underscore
+msgid ""
+"Use a timed exam to limit the time learners can spend on problems in this "
+"subsection. Learners must submit answers before the time expires. You can "
+"allow additional time for individual learners through the Instructor "
+"Dashboard."
+msgstr ""
+"استخدم امتحانًا موقوتًا للحدّ من الوقت الذي يمكن للمتعلّمين قضاؤه في حل "
+"مسائل هذا القسم الفرعي. يجب أن يقدّم المتعلّمون الإجابات قبل انتهاء الوقت "
+"المحدّد. كما ويمكنك السماح لأحد المتعلّمين بوقت إضافي باستخدام لوحة معلومات "
+"الأستاذ."
+
 #: cms/templates/js/validation-error-modal.underscore
 msgid ""
 "Please check the following validation feedbacks and reflect them in your "
@@ -810,11 +728,3 @@ msgid ""
 msgstr ""
 "يُرجى الاطلاع على ملاحظات التحقّق التالية وإجراء ما يلزم من تعديلات على "
 "الإعدادات الخاصة بمقررك."
-
-#: cms/templates/js/maintenance/force-published-course-response.underscore
-msgid ""
-"You have done a dry run of force publishing the course. Nothing has changed."
-" Had you run it, the following course versions would have been change."
-msgstr ""
-"لقد قمت بإجراء تنفيذ لنشر الدورة التدريبية. فلم يتغير شيء، عند التشغيل، "
-"إصدارات الدورة التالية قد يتم تغييرها."

--- a/translations/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
@@ -1735,7 +1735,7 @@ msgstr "الأدوات الخاصة بالوسائط المتعدّدة"
 
 #: lms/djangoapps/branding/api.py lms/templates/static_templates/donate.html
 msgid "Donate"
-msgstr "تبرَّع"
+msgstr "المركز"
 
 #: lms/djangoapps/branding/api.py lms/templates/footer.html
 #: lms/templates/static_templates/about.html
@@ -2073,7 +2073,7 @@ msgid ""
 "successfully completed, received a passing grade, and was awarded this "
 "{platform_name} {certificate_type} Certificate of Completion in "
 msgstr ""
-"قد نجح في إتمام المساق ونال درجة النجاح، ومُنِح بناءً على ذلك شهادة إتمام "
+"قد نجح في إتمام المقرر ونال درجة النجاح، ومُنِح بناءً على ذلك شهادة إتمام "
 "{certificate_type} من {platform_name}  في  "
 
 #. Translators: This text describes the purpose (and therefore, value) of a
@@ -2165,7 +2165,7 @@ msgstr "صدّق هذه الشهادة لنفسك"
 #, python-brace-format
 msgid "{platform_name} offers interactive online classes and MOOCs."
 msgstr ""
-"تُقدّم المنصّة {platform_name} صفوف ومساقات MOOC تفاعلية مُتاحة عبر "
+"تُقدّم المنصّة {platform_name} صفوف ومقررات MOOC تفاعلية مُتاحة عبر "
 "الإنترنت."
 
 #: lms/djangoapps/certificates/views/webview.py
@@ -2457,7 +2457,7 @@ msgstr "تقييم يجريه الزملاء"
 
 #: lms/djangoapps/courseware/courses.py
 msgid "Staff Assessment"
-msgstr "تقييم طاقم المساق"
+msgstr "تقييم طاقم المقرر"
 
 #: lms/djangoapps/courseware/courses.py
 msgid "Submission"
@@ -3997,7 +3997,7 @@ msgstr ""
 "بالأرقام التعريفية للمجموعات. ستُعتبر الكتلة مرئيّة للجميع في حال لم يتوفّر "
 "مفتاح لإعدادات مجموعة ما، أو كانت المجموعة الخاصّة بأرقام المجموعات "
 "فارغة.يُرجى أخذ العلم بوجوب تجاهل هذا الحقل في حال اقتصرت رؤية الكتلة على "
-"طاقم المساق. "
+"طاقم المقرر. "
 
 #: lms/djangoapps/lms_xblock/mixin.py xmodule/split_test_block.py
 msgid ""
@@ -4769,7 +4769,7 @@ msgstr "عرض المقرر"
 
 #: lms/templates/save_for_later/edx_ace/saveforlater/email/body.html
 msgid "Self-paced"
-msgstr "مساق دائم"
+msgstr "مقرر دائم"
 
 #: lms/templates/verify_student/edx_ace/verificationapproved/email/body.html
 msgid "ID Verification Approved"
@@ -6745,7 +6745,7 @@ msgid ""
 "This account has been temporarily locked due to excessive login failures. "
 "Try again later."
 msgstr ""
-"أُغلِقَ هذا الحساب مؤقّتًا نتيجة عدّة محاولات فاشلة لتسجيل الدخول. يُرجى "
+"أُغلِقَ هذا الحساب موقوتًا نتيجة عدّة محاولات فاشلة لتسجيل الدخول. يُرجى "
 "إعادة المحاولة لاحقًا."
 
 #: openedx/core/djangoapps/user_api/accounts/views.py
@@ -7977,7 +7977,7 @@ msgstr "قيم دخل عدديّة."
 
 #: xmodule/capa/responsetypes.py
 msgid "There was a problem with the staff answer to this problem."
-msgstr "حدثت مشكلة في إجابة طاقم المساق على هذه المسألة."
+msgstr "حدثت مشكلة في إجابة طاقم المقرر على هذه المسألة."
 
 #: xmodule/capa/responsetypes.py
 #, python-brace-format
@@ -8005,7 +8005,7 @@ msgstr "لا يجوز استخدام الأعداد المركّبة في مسا
 #: xmodule/capa/responsetypes.py
 msgid ""
 "There was a problem with the staff answer to this problem: complex boundary."
-msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المساق عن هذه المسألة: حدود مركّبة."
+msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المقرر عن هذه المسألة: حدود مركّبة."
 
 #. Translators: This is an error message for a math problem. If the instructor
 #. did not
@@ -8013,7 +8013,7 @@ msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المساق �
 #: xmodule/capa/responsetypes.py
 msgid ""
 "There was a problem with the staff answer to this problem: empty boundary."
-msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المساق عن هذه المسألة: حدود خالية."
+msgstr "نعتذر لحدوث مشكلة في إجابة طاقم المقرر عن هذه المسألة: حدود خالية."
 
 #. #-#-#-#-#  django-partial.po (edx-platform)  #-#-#-#-#
 #. Translators: Separator used in NumericalResponse to display multiple
@@ -8159,7 +8159,7 @@ msgstr "لم تُقدَّم إجابة لأجل {input_type}"
 
 #: xmodule/capa/responsetypes.py
 msgid "The Staff answer could not be interpreted as a number."
-msgstr "تعذّر تفسير إجابة طاقم المساق كعدد."
+msgstr "تعذّر تفسير إجابة طاقم المقرر كعدد."
 
 #: xmodule/capa/responsetypes.py
 #, python-brace-format
@@ -9003,7 +9003,7 @@ msgstr ""
 
 #: xmodule/course_block.py
 msgid "Certificates Downloadable Before End"
-msgstr "الشهادات القابلة للتنزيل قبل انتهاء المساق"
+msgstr "الشهادات القابلة للتنزيل قبل انتهاء المقرر"
 
 #: xmodule/course_block.py
 msgid ""
@@ -9107,7 +9107,7 @@ msgstr ""
 #. configuration values
 #: xmodule/course_block.py
 msgid "Certificate Web/HTML View Overrides"
-msgstr "تجاوز مشاهدة صفحة الويب/html للمساق"
+msgstr "تجاوز مشاهدة صفحة الويب/html للمقرر"
 
 #. Translators: These overrides allow for an alternative configuration of the
 #. certificate web view
@@ -9761,7 +9761,7 @@ msgstr[5] "لكنّه لا يوجد سوى {actual} مسائل مطابِقة."
 
 #: xmodule/library_content_block.py
 msgid "Edit the library configuration."
-msgstr "تعديل إعدادات المساق"
+msgstr "تعديل إعدادات المقرر"
 
 #: xmodule/library_content_block.py
 msgid "Invalid Library"
@@ -11693,7 +11693,7 @@ msgstr "مثال:  username@domain.com "
 
 #: cms/templates/settings.html lms/templates/courseware/program_marketing.html
 msgid "Instructors"
-msgstr "أساتذة المساق"
+msgstr "أساتذة المقرر"
 
 #: cms/templates/settings.html lms/templates/courseware/course_about.html
 msgid "Requirements"
@@ -12319,7 +12319,7 @@ msgstr "مشاهدة هذا المقرر كـ:"
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 #: lms/templates/preview_menu.html
 msgid "Staff"
-msgstr "طاقم المساق"
+msgstr "طاقم المقرر"
 
 #: lms/templates/preview_menu.html
 msgid "Learner"
@@ -12563,7 +12563,7 @@ msgstr "المجموعات غير النشطة"
 
 #: lms/templates/staff_problem_info.html
 msgid "Staff Debug Info"
-msgstr "المعلومات حول تصحيح أخطاء طاقم المساق"
+msgstr "المعلومات حول تصحيح أخطاء طاقم المقرر"
 
 #: lms/templates/staff_problem_info.html
 msgid "Submission history"
@@ -12599,7 +12599,7 @@ msgstr "إضافة تعليق"
 
 #: lms/templates/staff_problem_info.html
 msgid "Staff Debug:"
-msgstr "تصحيح طاقم المساق:"
+msgstr "تصحيح طاقم المقرر:"
 
 #: lms/templates/staff_problem_info.html
 msgid "Score (for override only)"
@@ -15545,7 +15545,7 @@ msgstr ""
 #: lms/templates/emails/business_order_confirmation_email.txt
 msgid "Your redeem url is: [[Enter Redeem URL here from the attached CSV]]"
 msgstr ""
-"رابط الاسترداد الخاص بمساقك هو: [[أدخل رابط الاسترداد هنا من ملف CSV "
+"رابط الاسترداد الخاص بمقررك هو: [[أدخل رابط الاسترداد هنا من ملف CSV "
 "المرفَق]]"
 
 #: lms/templates/emails/business_order_confirmation_email.txt
@@ -15621,7 +15621,7 @@ msgstr "الأسئلة الشائعة حول التحقق من الهوية: {fa
 #: lms/templates/emails/photo_submission_confirmation.txt
 #: lms/templates/emails/reverification_processed.txt
 msgid "The {platform_name} team"
-msgstr "فريق المساق {platform_name}"
+msgstr "فريق المقرر {platform_name}"
 
 #: lms/templates/emails/order_confirmation_email.txt
 msgid ""
@@ -16687,7 +16687,7 @@ msgstr "تحميل ملف CSV"
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid "Batch Beta Tester Addition"
-msgstr "إضافة مختبري النسخة التجريبية للمساق"
+msgstr "إضافة مختبري النسخة التجريبية للمقرر"
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid ""
@@ -16761,7 +16761,7 @@ msgstr ""
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid "Add Staff"
-msgstr "إضافة أعضاء إلى طاقم المساق"
+msgstr "إضافة أعضاء إلى طاقم المقرر"
 
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
 msgid "Admin"
@@ -17540,7 +17540,7 @@ msgid ""
 "You will now be shown a series of instructor-scored essays, and will be "
 "asked to score them yourself."
 msgstr ""
-"سيتم إطلاعك الآن على سلسلة من المقالات التي تم تقييمها من قبل موجّه المساق، "
+"سيتم إطلاعك الآن على سلسلة من المقالات التي تم تقييمها من قبل موجّه المقرر، "
 "وسيطلب منك تقييمهم بنفسك. "
 
 #: lms/templates/peer_grading/peer_grading_problem.html
@@ -17548,7 +17548,7 @@ msgid ""
 "Once you can score the essays similarly to an instructor, you will be ready "
 "to grade your peers."
 msgstr ""
-"لدى تمكنك من تقييم المقالات بطريقة مشابهة لما يقوم به موجّه المساق، ستكون "
+"لدى تمكنك من تقييم المقالات بطريقة مشابهة لما يقوم به موجّه المقرر، ستكون "
 "جاهزاً عندها للقيام بالتقييم لزملائك. "
 
 #: lms/templates/peer_grading/peer_grading_problem.html
@@ -18457,7 +18457,7 @@ msgid ""
 "We've logged the error and our staff is currently working to resolve this "
 "error as soon as possible."
 msgstr ""
-"لقد سجّلنا الخطأ، يعمل طاقم المساق حاليّاً على إيجاد حلّ له في أقرب وقت "
+"لقد سجّلنا الخطأ، يعمل طاقم المقرر حاليّاً على إيجاد حلّ له في أقرب وقت "
 "ممكن."
 
 #: cms/templates/accessibility.html
@@ -19617,8 +19617,8 @@ msgid ""
 "Draft your outline and build content anywhere. Simple drag and drop tools "
 "let you reorganize quickly."
 msgstr ""
-"يمكنك صياغة المخطّط الكلّي لمساقك وبناء محتواه أينما كنت. فإنّ أدوات السحب "
-"والإسقاط البسيطة المتاحة تسمح لك بإعادة تنظيم المساق بسرعة. "
+"يمكنك صياغة المخطّط الكلّي لمقررك وبناء محتواه أينما كنت. فإنّ أدوات السحب "
+"والإسقاط البسيطة المتاحة تسمح لك بإعادة تنظيم المقرر بسرعة. "
 
 #: cms/templates/howitworks.html
 msgid "Go A Week Or A Semester At A Time"
@@ -19642,7 +19642,7 @@ msgid ""
 "learning. Insert videos, discussions, and a wide variety of exercises with "
 "just a few clicks."
 msgstr ""
-"يسمح لك استوديو {studio_name} بجمع محتويات مساقك بطريقة تعزّز دراستك، إذ "
+"يسمح لك استوديو {studio_name} بجمع محتويات مقررك بطريقة تعزّز دراستك، إذ "
 "يمكنك تضمين الفيديوهات، والنقاشات، ومجموعة كبيرة من مختلف التمارين بمجرّد "
 "القيام بنقرات قليلة. "
 
@@ -19842,7 +19842,7 @@ msgid ""
 msgstr ""
 "تمرّ عملية الاستيراد بخمس مراحل. وعليك أن تبقى في هذه الصفحة في أوّل "
 "مرحلتين. ثمّ يمكنك مغادرة هذه الصفحة بعد أن تُستكمل مرحلة التفريغ. ولكنّنا "
-"نوصيك بعدم إجراء تغييرات أساسية في مساقك قبل أن تُستكمل عملية الاستيراد."
+"نوصيك بعدم إجراء تغييرات أساسية في مقررك قبل أن تُستكمل عملية الاستيراد."
 
 #: cms/templates/import.html
 msgid ""
@@ -20347,7 +20347,7 @@ msgid ""
 "The library creator must give you access to the library. Contact the library"
 " creator or administrator for the library you are helping to author."
 msgstr ""
-"يجب أن يمنحك منشئ المساق صلاحية دخول المكتبة. لذا يُرجى التواصل معه أو مع "
+"يجب أن يمنحك منشئ المقرر صلاحية دخول المكتبة. لذا يُرجى التواصل معه أو مع "
 "مشرِف المكتبة التي تساعد على تأليفها. "
 
 #: cms/templates/index.html
@@ -20625,7 +20625,7 @@ msgstr "الأدوار التي تتيح الدخول إلى المكتبة "
 #: cms/templates/manage_users_lib.html
 msgid "There are three access roles for libraries: User, Staff, and Admin."
 msgstr ""
-"هناك ثلاثة أدوار تتيح الدخول إلى المكتبات: المستخدم وطاقم المساق والمشرِف."
+"هناك ثلاثة أدوار تتيح الدخول إلى المكتبات: المستخدم وطاقم المقرر والمشرِف."
 
 #: cms/templates/manage_users_lib.html
 msgid ""
@@ -20775,7 +20775,7 @@ msgstr ""
 
 #: cms/templates/settings.html
 msgid "Self-Paced"
-msgstr "مساق دائم"
+msgstr "مقرر دائم"
 
 #: cms/templates/settings.html
 msgid ""
@@ -21203,7 +21203,7 @@ msgstr "لا يمكنك اعتماد التغييرات حتى يتم تحديث
 
 #: cms/templates/settings_advanced.html
 msgid "Your policy changes have been saved."
-msgstr "حُفّظت التغييرات التي أدخلتها على سياسة مساقك."
+msgstr "حُفّظت التغييرات التي أدخلتها على سياسة مقررك."
 
 #: cms/templates/settings_advanced.html
 msgid "There was an error saving your information. Please see below."
@@ -21277,7 +21277,7 @@ msgstr "أضف درجة"
 
 #: cms/templates/settings_graders.html
 msgid "Credit Eligibility"
-msgstr "الأهلية للمساق"
+msgstr "الأهلية للمقرر"
 
 #: cms/templates/settings_graders.html
 msgid "Settings for course credit eligibility"
@@ -21285,7 +21285,7 @@ msgstr "إعدادات الأهلية لمواد المقرر"
 
 #: cms/templates/settings_graders.html
 msgid "Minimum Credit-Eligible Grade:"
-msgstr "الدرجة الدنيا للأهلية للمساق:"
+msgstr "الدرجة الدنيا للأهلية للمقرر:"
 
 #: cms/templates/settings_graders.html
 msgid "Must be greater than or equal to the course passing grade"

--- a/translations/edx-platform/conf/locale/ar/LC_MESSAGES/djangojs.po
+++ b/translations/edx-platform/conf/locale/ar/LC_MESSAGES/djangojs.po
@@ -2291,7 +2291,7 @@ msgstr ""
 
 #: lms/static/js/instructor_dashboard/membership.js
 msgid "Error: You cannot remove yourself from the Instructor group!"
-msgstr "خطأ: لا يمكنك حذف نفسك من مجموعة أستاذ المساق!"
+msgstr "خطأ: لا يمكنك حذف نفسك من مجموعة أستاذ المقرر!"
 
 #: lms/static/js/instructor_dashboard/membership.js
 msgid "Errors"
@@ -2393,12 +2393,12 @@ msgid ""
 "allowed to enroll once they register:"
 msgstr ""
 "جرى بنجاح مراسلة المستخدمين التالين عبر البريد الإلكتروني حول معلومات "
-"التسجيل، وسيُسمح لهم بالالتحاق بالمساق حالما يسجّلون أنفسهم: "
+"التسجيل، وسيُسمح لهم بالالتحاق بالمقرر حالما يسجّلون أنفسهم: "
 
 #. Translators: A list of users appears after this sentence;
 #: lms/static/js/instructor_dashboard/membership.js
 msgid "These users will be allowed to enroll once they register:"
-msgstr "سيُسمح للمستخدمين التالين بالالتحاق بالمساق حالما يسجّلون أنفسهم: "
+msgstr "سيُسمح للمستخدمين التالين بالالتحاق بالمقرر حالما يسجّلون أنفسهم: "
 
 #. Translators: A list of users appears after this sentence;
 #: lms/static/js/instructor_dashboard/membership.js
@@ -2407,12 +2407,12 @@ msgid ""
 "enrolled once they register:"
 msgstr ""
 "جرى بنجاح مراسلة المستخدمين التالين عبر البريد الإلكتروني حول معلومات "
-"التسجيل، وسيجري إلحاقهم بالمساق حالما يسجّلون أنفسهم: "
+"التسجيل، وسيجري إلحاقهم بالمقرر حالما يسجّلون أنفسهم: "
 
 #. Translators: A list of users appears after this sentence;
 #: lms/static/js/instructor_dashboard/membership.js
 msgid "These users will be enrolled once they register:"
-msgstr "سيجري إلحاق المستخدمين التالين بالمساق حالما يسجّلون أنفسهم: "
+msgstr "سيجري إلحاق المستخدمين التالين بالمقرر حالما يسجّلون أنفسهم: "
 
 #. Translators: A list of users appears after this sentence;
 #: lms/static/js/instructor_dashboard/membership.js
@@ -5706,7 +5706,7 @@ msgstr "هل أنت متأكّد من رغبتك في حذف {email} من فري
 #: cms/static/js/factories/manage_users_lib.js
 #: common/static/common/templates/discussion/templates.underscore
 msgid "Staff"
-msgstr "طاقم المساق"
+msgstr "طاقم المقرر"
 
 #: cms/static/js/factories/manage_users.js
 #: cms/static/js/factories/manage_users_lib.js
@@ -5874,7 +5874,7 @@ msgstr "يجب أن يأتي تاريخ بدء المقرر بعد تاريخ ا
 #: cms/static/js/models/settings/course_details.js
 msgid "The enrollment start date cannot be after the enrollment end date."
 msgstr ""
-"لا يمكن لتاريخ بدء التسجيل في المساق أن يأتي بعد تاريخ انتهاء التسجيل فيه. "
+"لا يمكن لتاريخ بدء التسجيل في المقرر أن يأتي بعد تاريخ انتهاء التسجيل فيه. "
 
 #: cms/static/js/models/settings/course_details.js
 msgid "The enrollment end date cannot be after the course end date."
@@ -7721,7 +7721,7 @@ msgstr "أترك الفريق"
 #: lms/static/js/fixtures/donation.underscore
 #: lms/templates/dashboard/donation.underscore
 msgid "Donate"
-msgstr "تبرَّع"
+msgstr "المركز"
 
 #: lms/templates/api_admin/catalog-error.underscore
 msgid ""
@@ -9455,7 +9455,7 @@ msgid ""
 "values are 0-100"
 msgstr ""
 "حدد قسماً فرعياً أساسياً وأدخل النسبة المئوية الأدنى للعلامة والحد الأدنى "
-"لنسبة الإنجاز من المساق لتحديد الوصول إلى هذا القسم الفرعي، القيم المسموح "
+"لنسبة الإنجاز من المقرر لتحديد الوصول إلى هذا القسم الفرعي، القيم المسموح "
 "بها هي 0-100"
 
 #: cms/templates/js/access-editor.underscore
@@ -9889,7 +9889,7 @@ msgstr "متطلّب أساسي: %(prereq_display_name)s"
 
 #: cms/templates/js/course-outline.underscore
 msgid "Contains staff only content"
-msgstr "تحوي محتوىً خاص بطاقم المساق فقط."
+msgstr "تحوي محتوىً خاص بطاقم المقرر فقط."
 
 #: cms/templates/js/course-outline.underscore
 msgid "Unpublished changes to live content"
@@ -10136,7 +10136,7 @@ msgstr ""
 
 #: cms/templates/js/course_grade_policy.underscore
 msgid "Number of Droppable"
-msgstr "عدد المساقات التي يمكن الانسحاب منها"
+msgstr "عدد المقررات التي يمكن الانسحاب منها"
 
 #: cms/templates/js/course_grade_policy.underscore
 msgid ""
@@ -10501,7 +10501,7 @@ msgstr "مسودّة (لم تُنشَر قطّ) "
 
 #: cms/templates/js/publish-xblock.underscore
 msgid "Visible to Staff Only"
-msgstr "مرئيّة لطاقم المساق فقط"
+msgstr "مرئيّة لطاقم المقرر فقط"
 
 #: cms/templates/js/publish-xblock.underscore
 msgid "Published and Live"
@@ -10554,7 +10554,7 @@ msgstr "سيصبح مرئيّ من: "
 
 #: cms/templates/js/publish-xblock.underscore
 msgid "Staff Only"
-msgstr "طاقم المساق فقط"
+msgstr "طاقم المقرر فقط"
 
 #: cms/templates/js/publish-xblock.underscore
 #, python-format
@@ -10775,7 +10775,7 @@ msgstr "أنواع الاختبار"
 
 #: cms/templates/js/timed-examination-preference-editor.underscore
 msgid "Timed"
-msgstr "مؤقّت"
+msgstr "موقوت"
 
 #: cms/templates/js/timed-examination-preference-editor.underscore
 msgid ""
@@ -10784,7 +10784,7 @@ msgid ""
 "allow additional time for individual learners through the Instructor "
 "Dashboard."
 msgstr ""
-"استخدم امتحانًا مؤقّتًا للحدّ من الوقت الذي يمكن للمتعلّمين قضاؤه في حل "
+"استخدم امتحانًا موقوتًا للحدّ من الوقت الذي يمكن للمتعلّمين قضاؤه في حل "
 "مسائل هذا القسم الفرعي. يجب أن يقدّم المتعلّمون الإجابات قبل انتهاء الوقت "
 "المحدّد. كما ويمكنك السماح لأحد المتعلّمين بوقت إضافي باستخدام لوحة معلومات "
 "الأستاذ."


### PR DESCRIPTION
Sometimes translators add the word `مساق` even if the source translation don't contain the word `course`.

This is a translation issue that needs to be resolved. We're updating the source strings in Transifex while also patching them locally.


- Fixes #7 
- Fixes #6