### PR TITLE
add eox-nelp transaltions

### DIFF
--- a/custom-translations/eox-nelp/conf/locale/ar/LC_MESSAGES/djangojs.po
+++ b/custom-translations/eox-nelp/conf/locale/ar/LC_MESSAGES/djangojs.po
@@ -1,0 +1,8 @@
+msgid "public"
+msgstr "عام"
+
+msgid "private"
+msgstr "خاص"
+
+msgid "non_profit"
+msgstr "غير ربحي"


### PR DESCRIPTION
All custom translations should be in the `custom-translations` directory.