### PR TITLE
feat: add invalid form fields message to profile data modal translations

### DIFF
--- a/custom-translations/frontend-essentials/src/i18n/messages/ar.json
+++ b/custom-translations/frontend-essentials/src/i18n/messages/ar.json
@@ -329,5 +329,6 @@
   "essentials.ProfileDataModal.realEstateDevelopersServiceCenter": "مركز خدمات المطورين العقاريين",
   "essentials.ProfileDataModal.decisionSupportCenter": "مركز دعم اتخاذ القرار",
   "essentials.ProfileDataModal.entrustmentAndLiquidationCenter": "مركز الإسناد والتصفية",
-  "essentials.ProfileDataModal.other": "اخرى"
+  "essentials.ProfileDataModal.other": "اخرى",
+  "essentials.ProfileDataModal.invalidFormFields": "يبدو أن لديك بعض الحقول غير الصالحة في النموذج."
 }

--- a/custom-translations/frontend-essentials/src/i18n/messages/en.json
+++ b/custom-translations/frontend-essentials/src/i18n/messages/en.json
@@ -257,5 +257,6 @@
   "essentials.ProfileDataModal.realEstateDevelopersServiceCenter": "Real Estate Developers Service Center",
   "essentials.ProfileDataModal.decisionSupportCenter": "Decision Support Center",
   "essentials.ProfileDataModal.entrustmentAndLiquidationCenter": "Entrustment and Liquidation Center",
-  "essentials.ProfileDataModal.other": "Other"
+  "essentials.ProfileDataModal.other": "Other",
+  "essentials.ProfileDataModal.invalidFormFields": "Seems like you have some invalid fields in the form."
 }

--- a/translations/frontend-essentials/src/i18n/messages/ar.json
+++ b/translations/frontend-essentials/src/i18n/messages/ar.json
@@ -329,5 +329,6 @@
   "essentials.ProfileDataModal.realEstateDevelopersServiceCenter": "مركز خدمات المطورين العقاريين",
   "essentials.ProfileDataModal.decisionSupportCenter": "مركز دعم اتخاذ القرار",
   "essentials.ProfileDataModal.entrustmentAndLiquidationCenter": "مركز الإسناد والتصفية",
-  "essentials.ProfileDataModal.other": "اخرى"
+  "essentials.ProfileDataModal.other": "اخرى",
+  "essentials.ProfileDataModal.invalidFormFields": "يبدو أن لديك بعض الحقول غير الصالحة في النموذج."
 }

--- a/translations/frontend-essentials/src/i18n/messages/en.json
+++ b/translations/frontend-essentials/src/i18n/messages/en.json
@@ -257,5 +257,6 @@
   "essentials.ProfileDataModal.realEstateDevelopersServiceCenter": "Real Estate Developers Service Center",
   "essentials.ProfileDataModal.decisionSupportCenter": "Decision Support Center",
   "essentials.ProfileDataModal.entrustmentAndLiquidationCenter": "Entrustment and Liquidation Center",
-  "essentials.ProfileDataModal.other": "Other"
+  "essentials.ProfileDataModal.other": "Other",
+  "essentials.ProfileDataModal.invalidFormFields": "Seems like you have some invalid fields in the form."
 }


### PR DESCRIPTION
## Description
This pull request introduces a new translation key, `essentials.ProfileDataModal.invalidFormFields`, to handle error messages for invalid form fields in both Arabic and English. The changes ensure consistency across two translation files for each language.

### Translation Updates:

* Added the key `essentials.ProfileDataModal.invalidFormFields` with the Arabic translation "يبدو أن لديك بعض الحقول غير الصالحة في النموذج" in `custom-translations/frontend-essentials/src/i18n/messages/ar.json` and `translations/frontend-essentials/src/i18n/messages/ar.json`.
* Added the key `essentials.ProfileDataModal.invalidFormFields` with the English translation "Seems like you have some invalid fields in the form." in `custom-translations/frontend-essentials/src/i18n/messages/en.json` and `translations/frontend-essentials/src/i18n/messages/en.json`.